### PR TITLE
Add a command line option to store the history of swarm assignments

### DIFF
--- a/src/blockchain_db/berkeleydb/db_bdb.cpp
+++ b/src/blockchain_db/berkeleydb/db_bdb.cpp
@@ -2297,7 +2297,21 @@ void BlockchainBDB::set_service_node_data(const std::string& data)
 {
 }
 
-bool BlockchainBDB::get_service_node_data(std::string& data)
+void BlockchainBDB::set_swarm_state(uint64_t height, const std::string& data)
+{
+}
+
+bool BlockchainBDB::get_service_node_data(std::string& data) const
+{
+  return false;
+}
+
+bool BlockchainBDB::get_latest_swarm_state(uint64_t &height, std::string& data) const
+{
+  return false;
+}
+
+bool BlockchainBDB::clear_swarm_state_after(uint64_t height)
 {
   return false;
 }

--- a/src/blockchain_db/berkeleydb/db_bdb.h
+++ b/src/blockchain_db/berkeleydb/db_bdb.h
@@ -410,7 +410,10 @@ private:
   virtual void fixup(fixup_context const context);
 
   virtual void set_service_node_data(const std::string& data);
-  virtual bool get_service_node_data(std::string& data);
+  virtual bool get_service_node_data(std::string& data) const;
+  virtual void set_swarm_state(uint64_t height, const std::string& data);
+  virtual bool get_latest_swarm_state(uint64_t &height, std::string& data) const;
+  virtual bool clear_swarm_state_after(uint64_t height);
   virtual void clear_service_node_data();
 
   bool m_run_checkpoint;

--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -1808,11 +1808,14 @@ public:
   };
   virtual void fixup(fixup_context const context = {});
 
-  virtual bool get_output_blacklist(std::vector<uint64_t> &blacklist) const = 0;
-  virtual void add_output_blacklist(std::vector<uint64_t> const &blacklist) = 0;
-  virtual void set_service_node_data(const std::string& data)               = 0;
-  virtual bool get_service_node_data(std::string& data)                     = 0;
-  virtual void clear_service_node_data()                                    = 0;
+  virtual bool get_output_blacklist(std::vector<uint64_t> &blacklist) const      = 0;
+  virtual void add_output_blacklist(std::vector<uint64_t> const &blacklist)      = 0;
+  virtual void set_service_node_data(const std::string& data)                    = 0;
+  virtual bool get_service_node_data(std::string& data) const                    = 0;
+  virtual void set_swarm_state(uint64_t height, const std::string& data)         = 0;
+  virtual bool get_latest_swarm_state(uint64_t &height, std::string& data) const = 0;
+  virtual bool clear_swarm_state_after(uint64_t height)                          = 0;
+  virtual void clear_service_node_data()                                         = 0;
 
   /**
    * @brief set whether or not to automatically remove logs

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -73,6 +73,7 @@ typedef struct mdb_txn_cursors
   MDB_cursor *m_txc_hf_versions;
 
   MDB_cursor *m_txc_service_node_data;
+  MDB_cursor *m_txc_swarm_assignment_history;
   MDB_cursor *m_txc_output_blacklist;
   MDB_cursor *m_txc_properties;
 } mdb_txn_cursors;
@@ -97,6 +98,7 @@ typedef struct mdb_txn_cursors
 #define m_cur_alt_blocks	m_cursors->m_txc_alt_blocks
 #define m_cur_hf_versions	m_cursors->m_txc_hf_versions
 #define m_cur_service_node_data	m_cursors->m_txc_service_node_data
+#define m_cur_swarm_assignment_history m_cursors->m_txc_swarm_assignment_history
 #define m_cur_properties	m_cursors->m_txc_properties
 
 typedef struct mdb_rflags
@@ -122,6 +124,7 @@ typedef struct mdb_rflags
   bool m_rf_alt_blocks;
   bool m_rf_hf_versions;
   bool m_rf_service_node_data;
+  bool m_rf_swarm_assignment_history;
   bool m_rf_properties;
 } mdb_rflags;
 
@@ -456,7 +459,13 @@ private:
 
   bool get_block_checkpoint_internal(uint64_t height, checkpoint_t &checkpoint, MDB_cursor_op op) const;
   void set_service_node_data(const std::string& data) override;
-  bool get_service_node_data(std::string& data) override;
+  bool get_service_node_data(std::string& data) const override;
+  // Set swarm state (swarm id assignments) to `data` at `height`
+  void set_swarm_state(uint64_t height, const std::string& data) override;
+  // Return the latest available swarm state not more recent than `height`
+  bool get_latest_swarm_state(uint64_t &height, std::string& data) const override;
+  // Remove all entries after `height`
+  bool clear_swarm_state_after(uint64_t height) override;
   void clear_service_node_data() override;
 
 private:
@@ -490,6 +499,8 @@ private:
   MDB_dbi m_hf_versions;
 
   MDB_dbi m_service_node_data;
+
+  MDB_dbi m_swarm_assignment_history;
 
   MDB_dbi m_properties;
 

--- a/src/blockchain_db/testdb.h
+++ b/src/blockchain_db/testdb.h
@@ -168,7 +168,10 @@ public:
   virtual bool get_output_blacklist   (std::vector<uint64_t> &blacklist)       const override { return false; }
   virtual void add_output_blacklist   (std::vector<uint64_t> const &blacklist)       override { }
   virtual void set_service_node_data  (const std::string& data)                      override { }
-  virtual bool get_service_node_data  (std::string& data)                            override { return false; }
+  virtual bool get_service_node_data  (std::string& data)                      const override { return false; }
+  virtual void set_swarm_state        (uint64_t height, const std::string& data)     override { }
+  virtual bool get_latest_swarm_state (uint64_t &height, std::string& data)    const override { return false; }
+  virtual bool clear_swarm_state_after(uint64_t height)                              override { return false; }
   virtual void clear_service_node_data()                                             override { }
 
   virtual void add_alt_block(const crypto::hash &blkid, const cryptonote::alt_block_data_t &data, const cryptonote::blobdata &blob) override {}

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -232,6 +232,12 @@ namespace cryptonote
     "the entire history.  Requires considerably more memory and block chain storage.",
     0};
 
+  static const command_line::arg_descriptor<bool> arg_store_swarm_history = {
+    "store-swarm-history",
+    "Store the history of swarm assignments to service nodes. Requires considerably more blockchain storage. The data "
+    "is only stored for blocks that represent change in swarm assignments",
+    false
+  };
 
   //-----------------------------------------------------------------------------------------------
   core::core(i_cryptonote_protocol* pprotocol):
@@ -331,6 +337,7 @@ namespace cryptonote
 
     command_line::add_arg(desc, arg_recalculate_difficulty);
     command_line::add_arg(desc, arg_store_quorum_history);
+    command_line::add_arg(desc, arg_store_swarm_history);
 #if defined(LOKI_ENABLE_INTEGRATION_TEST_HOOKS)
     command_line::add_arg(desc, loki::arg_integration_test_hardforks_override);
     command_line::add_arg(desc, loki::arg_integration_test_shared_mem_name);
@@ -715,6 +722,7 @@ namespace cryptonote
       m_service_node_list.set_db_pointer(initialized_db);
 
       m_service_node_list.set_quorum_history_storage(command_line::get_arg(vm, arg_store_quorum_history));
+      m_service_node_list.set_store_swarm_history(command_line::get_arg(vm, arg_store_swarm_history));
 
       m_blockchain_storage.hook_block_added(m_service_node_list);
       m_blockchain_storage.hook_blockchain_detached(m_service_node_list);
@@ -2224,6 +2232,11 @@ namespace cryptonote
   {
     std::vector<service_nodes::service_node_pubkey_info> result = m_service_node_list.get_service_node_list_state(service_node_pubkeys);
     return result;
+  }
+  //-----------------------------------------------------------------------------------------------
+  std::vector<service_nodes::swarm_id_entry_t> core::get_swarm_state(uint64_t &height) const
+  {
+    return m_service_node_list.get_swarm_state(height);
   }
   //-----------------------------------------------------------------------------------------------
   bool core::add_service_node_vote(const service_nodes::quorum_vote_t& vote, vote_verification_context &vvc)

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -799,6 +799,8 @@ namespace cryptonote
       */
      std::vector<service_nodes::service_node_pubkey_info> get_service_node_list_state(const std::vector<crypto::public_key>& service_node_pubkeys) const;
 
+     std::vector<service_nodes::swarm_id_entry_t> get_swarm_state(uint64_t &height) const;
+
      /**
        * @brief get whether `pubkey` is known as a service node.
        *

--- a/src/cryptonote_core/service_node_swarm.cpp
+++ b/src/cryptonote_core/service_node_swarm.cpp
@@ -209,7 +209,7 @@ namespace service_nodes
   void calc_swarm_changes(swarm_snode_map_t &swarm_to_snodes, uint64_t seed)
   {
 
-    if (swarm_to_snodes.size() == 0)
+    if (swarm_to_snodes.empty())
     {
       // nothing to do
       return;

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2806,6 +2806,28 @@ namespace cryptonote
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
+  bool core_rpc_server::on_get_swarm_state(const COMMAND_RPC_GET_SWARM_STATE::request& req,
+                                           COMMAND_RPC_GET_SWARM_STATE::response& res,
+                                           epee::json_rpc::error& error_resp,
+                                           const connection_context* ctx) const
+  {
+    uint64_t height_in_out = req.height;
+    const auto swarm_state = m_core.get_swarm_state(height_in_out);
+
+    res.entries.reserve(swarm_state.size());
+    res.height = height_in_out;
+
+    for (const auto &entry : swarm_state)
+    {
+      res.entries.emplace_back();
+      auto &res_entry = res.entries.back();
+      res_entry.service_node_pubkey = string_tools::pod_to_hex(entry.pubkey);
+      res_entry.swarm_id = entry.swarm_id;
+    }
+
+    return true;
+  }
+  //------------------------------------------------------------------------------------------------------------------------------
   bool core_rpc_server::on_get_all_service_nodes(const COMMAND_RPC_GET_SERVICE_NODES::request& req, COMMAND_RPC_GET_SERVICE_NODES::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx)
   {
     auto req_all = req;

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -184,8 +184,9 @@ namespace cryptonote
         MAP_JON_RPC_WE("get_all_service_nodes",                     on_get_all_service_nodes, COMMAND_RPC_GET_SERVICE_NODES)
         MAP_JON_RPC_WE("get_all_service_nodes_keys",                on_get_all_service_nodes_keys, COMMAND_RPC_GET_ALL_SERVICE_NODES_KEYS)
         MAP_JON_RPC_WE("get_n_service_nodes",                       on_get_n_service_nodes, COMMAND_RPC_GET_N_SERVICE_NODES)
+        MAP_JON_RPC_WE("get_swarm_state",                           on_get_swarm_state, COMMAND_RPC_GET_SWARM_STATE)
         MAP_JON_RPC_WE("get_staking_requirement",                   on_get_staking_requirement, COMMAND_RPC_GET_STAKING_REQUIREMENT)
-        MAP_JON_RPC_WE("get_checkpoints",                          on_get_checkpoints, COMMAND_RPC_GET_CHECKPOINTS)
+        MAP_JON_RPC_WE("get_checkpoints",                           on_get_checkpoints, COMMAND_RPC_GET_CHECKPOINTS)
         MAP_JON_RPC_WE_IF("perform_blockchain_test",                on_perform_blockchain_test, COMMAND_RPC_PERFORM_BLOCKCHAIN_TEST, !m_restricted)
         MAP_JON_RPC_WE_IF("storage_server_ping",                    on_storage_server_ping, COMMAND_RPC_STORAGE_SERVER_PING, !m_restricted)
         MAP_JON_RPC_WE("get_service_nodes_state_changes",           on_get_service_nodes_state_changes, COMMAND_RPC_GET_SN_STATE_CHANGES)
@@ -271,6 +272,7 @@ namespace cryptonote
     bool on_get_service_node_key(const COMMAND_RPC_GET_SERVICE_NODE_KEY::request& req, COMMAND_RPC_GET_SERVICE_NODE_KEY::response& res, epee::json_rpc::error &error_resp, const connection_context *ctx = NULL);
     bool on_get_service_nodes(const COMMAND_RPC_GET_SERVICE_NODES::request& req, COMMAND_RPC_GET_SERVICE_NODES::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
     bool on_get_n_service_nodes(const COMMAND_RPC_GET_N_SERVICE_NODES::request& req, COMMAND_RPC_GET_N_SERVICE_NODES::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
+    bool on_get_swarm_state(const COMMAND_RPC_GET_SWARM_STATE::request& req, COMMAND_RPC_GET_SWARM_STATE::response& res, epee::json_rpc::error& error_resp, const connection_context* ctx) const;
     bool on_get_all_service_nodes_keys(const COMMAND_RPC_GET_ALL_SERVICE_NODES_KEYS::request& req, COMMAND_RPC_GET_ALL_SERVICE_NODES_KEYS::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx);
     bool on_get_all_service_nodes(const COMMAND_RPC_GET_SERVICE_NODES::request& req, COMMAND_RPC_GET_SERVICE_NODES::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
     bool on_get_staking_requirement(const COMMAND_RPC_GET_STAKING_REQUIREMENT::request& req, COMMAND_RPC_GET_STAKING_REQUIREMENT::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -3008,6 +3008,42 @@ namespace cryptonote
     typedef epee::misc_utils::struct_init<response_t> response;
   };
 
+  LOKI_RPC_DOC_INTROSPECT
+  // Get swarm id assignments at a particular blockchain height,
+  // (--store_swarm_histoly option is required)
+  struct COMMAND_RPC_GET_SWARM_STATE
+  {
+    struct request
+    {
+      uint64_t height; // The blockchain height
+      BEGIN_KV_SERIALIZE_MAP()
+      KV_SERIALIZE(height);
+      END_KV_SERIALIZE_MAP()
+    };
+
+    // Swarm id assignment
+    struct entry_t
+    {
+      std::string service_node_pubkey;
+      uint64_t swarm_id;
+
+      BEGIN_KV_SERIALIZE_MAP()
+      KV_SERIALIZE(service_node_pubkey)
+      KV_SERIALIZE(swarm_id)
+      END_KV_SERIALIZE_MAP()
+    };
+
+    struct response
+    {
+      uint64_t height; // The earliest height for which this very response is accurate
+      std::vector<entry_t> entries; // Swarm id assignments
+      BEGIN_KV_SERIALIZE_MAP()
+      KV_SERIALIZE(height);
+      KV_SERIALIZE(entries);
+      END_KV_SERIALIZE_MAP()
+    };
+  };
+
   struct COMMAND_RPC_STORAGE_SERVER_PING
   {
     struct request

--- a/tests/unit_tests/testdb.h
+++ b/tests/unit_tests/testdb.h
@@ -153,7 +153,10 @@ public:
   virtual bool get_output_blacklist   (std::vector<uint64_t> &blacklist)       const override { return false; }
   virtual void add_output_blacklist   (std::vector<uint64_t> const &blacklist)       override { }
   virtual void set_service_node_data  (const std::string& data)                      override { }
-  virtual bool get_service_node_data  (std::string& data)                            override { return false; }
+  virtual bool get_service_node_data  (std::string& data)                      const override { return false; }
+  virtual void set_swarm_state        (uint64_t height, const std::string& data)     override { }
+  virtual bool get_latest_swarm_state (uint64_t &height, std::string& data)          override { return false; }
+  virtual bool clear_swarm_state_after(uint64_t height)                              override { return false; }
   virtual void clear_service_node_data()                                             override { }
 
   virtual cryptonote::transaction get_pruned_tx(const crypto::hash& h) const override { return {}; };


### PR DESCRIPTION
Adds `--store-swarm-history` option to record swarm assignments for blocks where swarm assignments change.

Adds a new rpc method `get_swarm_state` to retrieve the swarm assignments for any blockchain height. The height returned in response may be smaller/earlier than the one requested, indicating the earliest height at which the swarms were in the same state as that for the height requested.

Sample request:
```
{
    "jsonrpc":"2.0",
    "id":"0",
    "method":"get_swarm_state",
    "params": {
    	"height": 3500
    }
}
```

Sample response:
```
{
  "id": "0",
  "jsonrpc": "2.0",
  "result": {
    "entries": [
      {
        "service_node_pubkey": "f5527f6ff9c3628f2a462803d2c526a6f996708b66388c3598b2123b0b82391e",
        "swarm_id": 0
      },
      {
        "service_node_pubkey": "fcb147715be4f8f3cd5d25aae839e217bda00bb7bb02c21b00cdd5a18cd38aba",
        "swarm_id": 0
      },
      {
        "service_node_pubkey": "fff1104f6073cbda7eac68965ce1e75ad40d36f534ad5aa3f65b91a626cd4624",
        "swarm_id": 0
      }
    ],
    "height": 3390
  }
}
```

At the moment this doesn't rescan the service node list automatically for missing entires, so a manual rescan would be necessary if we want to get old entries. (This could be added in a later PR, but doesn't seem like a high priority as there is an easy workaround.)
