### PR TITLE
Wallet lock fix

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -5734,7 +5734,7 @@ bool simple_wallet::confirm_and_send_tx(std::vector<cryptonote::address_parse_in
 
       if (lock_time_in_blocks > 0)
       {
-        float days = lock_time_in_blocks / BLOCKS_EXPECTED_IN_DAYS(1.f);
+        float days = lock_time_in_blocks / float{BLOCKS_EXPECTED_IN_DAYS(1)};
         prompt << boost::format(tr(".\nThis transaction (including %s change) will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)")) % cryptonote::print_money(change) % ((unsigned long long)unlock_block) % days;
       }
 


### PR DESCRIPTION
Fix a warning and a bug in simplewallet:
- the "days" calculation was being done with integer division rather than floating point division and thus truncating fractional lock times.
~~- remove an unused variable.~~ (Merged in #1396)