### PR TITLE
Add SN rewards to miner block, even if 0

### DIFF
--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -366,27 +366,19 @@ namespace cryptonote
       {
         leader_reward += reward_parts.miner_fee;
       }
-      else
+      else if (reward_parts.miner_fee)
       {
-        // Alternative Block Producer (receives just miner fee)
+        // Alternative Block Producer (receives just miner fee, if there is one)
         service_nodes::payout const &producer = miner_tx_context.pulse_block_producer;
         std::vector<uint64_t> split_rewards   = distribute_reward_by_portions(producer.payouts, reward_parts.miner_fee, true /*distribute_remainder*/);
 
         for (size_t i = 0; i < producer.payouts.size(); i++)
-        {
-          auto const &payee = producer.payouts[i];
-          if (uint64_t amount = split_rewards[i]; amount)
-            rewards[rewards_length++] = {reward_type::snode, payee.address, amount};
-        }
+          rewards[rewards_length++] = {reward_type::snode, producer.payouts[i].address, split_rewards[i]};
       }
 
       std::vector<uint64_t> split_rewards = distribute_reward_by_portions(leader.payouts, leader_reward, true /*distribute_remainder*/);
       for (size_t i = 0; i < leader.payouts.size(); i++)
-      {
-        auto const &payee = leader.payouts[i];
-        if (uint64_t amount = split_rewards[i]; amount)
-          rewards[rewards_length++] = {reward_type::snode, payee.address, amount};
-      }
+        rewards[rewards_length++] = {reward_type::snode, leader.payouts[i].address, split_rewards[i]};
     }
     else
     {
@@ -403,11 +395,7 @@ namespace cryptonote
                                           reward_parts.service_node_total,
                                           hard_fork_version >= cryptonote::network_version_16_pulse /*distribute_remainder*/);
         for (size_t i = 0; i < leader.payouts.size(); i++)
-        {
-          auto const &payee = leader.payouts[i];
-          if (split_rewards[i])
-            rewards[rewards_length++] = {reward_type::snode, payee.address, split_rewards[i]};
-        }
+          rewards[rewards_length++] = {reward_type::snode, leader.payouts[i].address, split_rewards[i]};
       }
     }
 


### PR DESCRIPTION
Network validation expects N outputs when there are N contributors, but
if any of the received reward amounts was 0 we were skipping it,
leading to a block that failed validation.

This happened at blocks 739994 and 740010 when recently registered SNs
*with* a contributor reached the top of the reward list with a 100% fee;
this caused the second SN reward recipient amount to be 0, which then
got left off the block and then failed block validation.

This doesn't require a hard fork to fix -- it just requires block
producers to update to start including the 0 payout in such cases which
makes the network happy with the block.

(This may result in some stalls when we hit those SNs again, but as long
as enough of the network has upgraded we should unstall when an upgraded
node gets randomly selected to produce a backup block).