### PR TITLE
Fix lokimq -> oxenmq namespace that crept in

### DIFF
--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -60,7 +60,6 @@ extern "C" {
 #include "uptime_proof.h"
 #include "service_node_rules.h"
 #include "service_node_swarm.h"
-#include <lokimq/bt_serialize.h>
 #include "version.h"
 
 #undef OXEN_DEFAULT_LOG_CATEGORY

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -38,8 +38,6 @@
 #include "cryptonote_core/service_node_quorum_cop.h"
 #include "common/util.h"
 
-#include <lokimq/bt_serialize.h>
-
 namespace cryptonote
 {
 class Blockchain;

--- a/src/cryptonote_core/uptime_proof.cpp
+++ b/src/cryptonote_core/uptime_proof.cpp
@@ -27,19 +27,21 @@ Proof::Proof(uint32_t sn_public_ip, uint16_t sn_storage_port, uint16_t sn_storag
 Proof::Proof(const std::string& serialized_proof)
 {
   try {
-    const lokimq::bt_dict bt_proof = lokimq::bt_deserialize<lokimq::bt_dict>(serialized_proof);
+    using namespace oxenmq;
+
+    const bt_dict bt_proof = bt_deserialize<bt_dict>(serialized_proof);
     //snode_version <X,X,X>
-    const lokimq::bt_list& bt_version = var::get<lokimq::bt_list>(bt_proof.at("v"));
+    const bt_list& bt_version = var::get<bt_list>(bt_proof.at("v"));
     int k = 0;
-    for (lokimq::bt_value const &i: bt_version){
-      version[k++] = static_cast<uint16_t>(lokimq::get_int<unsigned>(i));
+    for (bt_value const &i: bt_version){
+      version[k++] = static_cast<uint16_t>(get_int<unsigned>(i));
     }
     //timestamp
-    timestamp = lokimq::get_int<unsigned>(bt_proof.at("t"));
+    timestamp = get_int<unsigned>(bt_proof.at("t"));
     //public_ip
     bool succeeded = epee::string_tools::get_ip_int32_from_string(public_ip, var::get<std::string>(bt_proof.at("ip")));
     //storage_port
-    storage_port = static_cast<uint16_t>(lokimq::get_int<unsigned>(bt_proof.at("s")));
+    storage_port = static_cast<uint16_t>(get_int<unsigned>(bt_proof.at("s")));
     //pubkey_ed25519
     pubkey_ed25519 = tools::make_from_guts<crypto::ed25519_public_key>(var::get<std::string>(bt_proof.at("pke")));
     //pubkey
@@ -48,20 +50,20 @@ Proof::Proof(const std::string& serialized_proof)
     else
       std::memcpy(pubkey.data, pubkey_ed25519.data, 32);
     //qnet_port
-    qnet_port = lokimq::get_int<unsigned>(bt_proof.at("q"));
+    qnet_port = get_int<unsigned>(bt_proof.at("q"));
     //storage_lmq_port
-    storage_lmq_port = lokimq::get_int<unsigned>(bt_proof.at("slp"));
+    storage_lmq_port = get_int<unsigned>(bt_proof.at("slp"));
     //storage_version
-    const lokimq::bt_list& bt_storage_version = var::get<lokimq::bt_list>(bt_proof.at("sv"));
+    const bt_list& bt_storage_version = var::get<bt_list>(bt_proof.at("sv"));
     k = 0;
-    for (lokimq::bt_value const &i: bt_storage_version){
-      storage_server_version[k++] = static_cast<uint16_t>(lokimq::get_int<unsigned>(i));
+    for (bt_value const &i: bt_storage_version){
+      storage_server_version[k++] = static_cast<uint16_t>(get_int<unsigned>(i));
     }
     //lokinet_version
-    const lokimq::bt_list& bt_lokinet_version = var::get<lokimq::bt_list>(bt_proof.at("lv"));
+    const bt_list& bt_lokinet_version = var::get<bt_list>(bt_proof.at("lv"));
     k = 0;
-    for (lokimq::bt_value const &i: bt_lokinet_version){
-      lokinet_version[k++] = static_cast<uint16_t>(lokimq::get_int<unsigned>(i));
+    for (bt_value const &i: bt_lokinet_version){
+      lokinet_version[k++] = static_cast<uint16_t>(get_int<unsigned>(i));
     }
   } catch (const std::exception& e) {
     MWARNING("deserialization failed: " <<  e.what());
@@ -74,17 +76,17 @@ crypto::hash Proof::hash_uptime_proof() const
 {
   crypto::hash result;
 
-  std::string serialized_proof = lokimq::bt_serialize(bt_encode_uptime_proof());
+  std::string serialized_proof = bt_serialize(bt_encode_uptime_proof());
   size_t buf_size = serialized_proof.size();
   crypto::cn_fast_hash(serialized_proof.data(), buf_size, result);
   return result;
 }
 
-lokimq::bt_dict Proof::bt_encode_uptime_proof() const
+oxenmq::bt_dict Proof::bt_encode_uptime_proof() const
 {
-  lokimq::bt_dict encoded_proof{
+  oxenmq::bt_dict encoded_proof{
     //version
-    {"v", lokimq::bt_list{{version[0], version[1], version[2]}}},
+    {"v", oxenmq::bt_list{{version[0], version[1], version[2]}}},
     //timestamp
     {"t", timestamp},
     //public_ip
@@ -98,9 +100,9 @@ lokimq::bt_dict Proof::bt_encode_uptime_proof() const
     //storage_lmq_port
     {"slp", storage_lmq_port},
     //storage_version
-    {"sv", lokimq::bt_list{{storage_server_version[0], storage_server_version[1], storage_server_version[2]}}},
+    {"sv", oxenmq::bt_list{{storage_server_version[0], storage_server_version[1], storage_server_version[2]}}},
     //lokinet_version
-    {"lv", lokimq::bt_list{{lokinet_version[0], lokinet_version[1], lokinet_version[2]}}},
+    {"lv", oxenmq::bt_list{{lokinet_version[0], lokinet_version[1], lokinet_version[2]}}},
   };
 
   if (pubkey != pubkey_ed25519) encoded_proof["pk"] = tools::view_guts(pubkey);
@@ -111,7 +113,7 @@ lokimq::bt_dict Proof::bt_encode_uptime_proof() const
 cryptonote::NOTIFY_BTENCODED_UPTIME_PROOF::request Proof::generate_request() const
 {
   cryptonote::NOTIFY_BTENCODED_UPTIME_PROOF::request request;
-  request.proof = lokimq::bt_serialize(this->bt_encode_uptime_proof());
+  request.proof = bt_serialize(this->bt_encode_uptime_proof());
   request.sig = tools::view_guts(this->sig);
   request.ed_sig = tools::view_guts(this->sig_ed25519);
 

--- a/src/cryptonote_core/uptime_proof.h
+++ b/src/cryptonote_core/uptime_proof.h
@@ -2,7 +2,7 @@
 
 #include "service_node_list.h"
 #include "../cryptonote_protocol/cryptonote_protocol_defs.h"
-#include <lokimq/lokimq.h>
+#include <oxenmq/bt_serialize.h>
 
 namespace uptime_proof
 {
@@ -29,7 +29,7 @@ public:
   Proof(uint32_t sn_public_ip, uint16_t sn_storage_port, uint16_t sn_storage_lmq_port, std::array<uint16_t, 3> ss_version, uint16_t quorumnet_port, std::array<uint16_t, 3> lokinet_version, const service_nodes::service_node_keys& keys);
 
   Proof(const std::string& serialized_proof);
-  lokimq::bt_dict bt_encode_uptime_proof() const;
+  oxenmq::bt_dict bt_encode_uptime_proof() const;
 
   crypto::hash hash_uptime_proof() const;
 


### PR DESCRIPTION
A recent PR started off prior to the rebrand code and was apparently
still using the legacy header names.