### PR TITLE
bump HF versions

### DIFF
--- a/src/cryptonote_basic/hardfork.cpp
+++ b/src/cryptonote_basic/hardfork.cpp
@@ -75,6 +75,7 @@ static constexpr HardFork::Params mainnet_hard_forks[] =
   { network_version_15_lns,                 496969, 0, 1585105200 }, // 2020-03-25 14:00AEDT (03:00UTC)
   { network_version_16_pulse,               641111, 0, 1602464400 }, // 2020-10-12 12:00AEDT (01:00UTC)
   { network_version_17,                     641111 + BLOCKS_EXPECTED_IN_DAYS(180), 0, 1602464400 + 180*24*60*60 }, // HF16 + 180 days
+  { network_version_18,                     641111 + BLOCKS_EXPECTED_IN_DAYS(200), 0, 1602464400 + 200*24*60*60 }, // HF16 + 200 days
 };
 
 static constexpr HardFork::Params testnet_hard_forks[] =
@@ -90,6 +91,7 @@ static constexpr HardFork::Params testnet_hard_forks[] =
   { network_version_15_lns,                 244777, 0, 1583940000 }, // 2020-03-11 15:20UTC
   { network_version_16_pulse,               382222, 0, 1600468200 }, // 2020-09-18 22:30UTC
   { network_version_17,                     447275, 0, 1608276840 }, // 2020-12-18 05:34UTC 
+  { network_version_18,                     447275, 0, 1608276840 }, // 2020-12-18 05:34UTC 
 };
 
 static constexpr HardFork::Params devnet_hard_forks[] =

--- a/src/cryptonote_basic/hardfork.cpp
+++ b/src/cryptonote_basic/hardfork.cpp
@@ -75,7 +75,6 @@ static constexpr HardFork::Params mainnet_hard_forks[] =
   { network_version_15_lns,                 496969, 0, 1585105200 }, // 2020-03-25 14:00AEDT (03:00UTC)
   { network_version_16_pulse,               641111, 0, 1602464400 }, // 2020-10-12 12:00AEDT (01:00UTC)
   { network_version_17,                     641111 + BLOCKS_EXPECTED_IN_DAYS(180), 0, 1602464400 + 180*24*60*60 }, // HF16 + 180 days
-  { network_version_18,                     641111 + BLOCKS_EXPECTED_IN_DAYS(200), 0, 1602464400 + 200*24*60*60 }, // HF16 + 200 days
 };
 
 static constexpr HardFork::Params testnet_hard_forks[] =
@@ -91,7 +90,7 @@ static constexpr HardFork::Params testnet_hard_forks[] =
   { network_version_15_lns,                 244777, 0, 1583940000 }, // 2020-03-11 15:20UTC
   { network_version_16_pulse,               382222, 0, 1600468200 }, // 2020-09-18 22:30UTC
   { network_version_17,                     447275, 0, 1608276840 }, // 2020-12-18 05:34UTC 
-  { network_version_18,                     447275, 0, 1608276840 }, // 2020-12-18 05:34UTC 
+  { network_version_18,                     501750, 0, 1616631051 }, // 2021-03-25 12:10UTC 
 };
 
 static constexpr HardFork::Params devnet_hard_forks[] =

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -194,7 +194,7 @@ constexpr uint64_t BLOCKS_EXPECTED_IN_YEARS(int years) { return BLOCKS_EXPECTED_
 #define HF_VERSION_EFFECTIVE_SHORT_TERM_MEDIAN_IN_PENALTY cryptonote::network_version_16_pulse
 #define HF_VERSION_PULSE cryptonote::network_version_16_pulse
 #define HF_VERSION_CLSAG                        cryptonote::network_version_16_pulse
-#define HF_VERSION_PROOF_BTENC                  cryptonote::network_version_17
+#define HF_VERSION_PROOF_BTENC                  cryptonote::network_version_18
 
 #define PER_KB_FEE_QUANTIZATION_DECIMALS        8
 
@@ -331,6 +331,7 @@ namespace cryptonote
     network_version_15_lns,
     network_version_16_pulse,
     network_version_17, // future HF
+    network_version_18, // future HF
 
     network_version_count,
   };

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1935,7 +1935,7 @@ namespace cryptonote
     bool relayed;
     auto height = get_current_blockchain_height();
     auto hf_version = get_hard_fork_version(height);
-    //TODO: remove after HF17
+    //TODO: remove after HF18
     if (hf_version < HF_VERSION_PROOF_BTENC) {
       NOTIFY_UPTIME_PROOF::request req = m_service_node_list.generate_uptime_proof(m_sn_public_ip, m_storage_port, m_storage_lmq_port, m_quorumnet_port);
       relayed = get_protocol()->relay_uptime_proof(req, fake_context);

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -2745,7 +2745,7 @@ namespace service_nodes
     return true;
   }
 
-  //TODO: remove after HF17
+  //TODO: remove after HF18
   crypto::hash service_node_list::hash_uptime_proof(const cryptonote::NOTIFY_UPTIME_PROOF::request &proof) const
   {
     size_t buf_size;
@@ -2848,7 +2848,7 @@ namespace service_nodes
   };
 
 
-  //TODO remove after HF17
+  //TODO remove after HF18
   bool proof_info::update(uint64_t ts,
                           uint32_t ip,
                           uint16_t s_port,
@@ -2902,7 +2902,7 @@ namespace service_nodes
 
 #define REJECT_PROOF(log) do { LOG_PRINT_L2("Rejecting uptime proof from " << proof.pubkey << ": " log); return false; } while (0)
 
-  //TODO remove after HF17
+  //TODO remove after HF18
   bool service_node_list::handle_uptime_proof(cryptonote::NOTIFY_UPTIME_PROOF::request const &proof, bool &my_uptime_proof_confirmation, crypto::x25519_public_key &x25519_pkey)
   {
     uint8_t const hf_version = m_blockchain.get_current_hard_fork_version();

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -171,7 +171,7 @@ namespace service_nodes
     // Note that this does not update the m_x25519_to_pub map if the x25519 key changes (that's the
     // caller's responsibility).
     bool update(uint64_t ts, std::unique_ptr<uptime_proof::Proof> new_proof, const crypto::x25519_public_key &pk_x2);
-    // TODO: remove after HF 17
+    // TODO: remove after HF18
     bool update(uint64_t ts, uint32_t ip, uint16_t s_port, uint16_t s_lmq_port, uint16_t q_port, std::array<uint16_t, 3> ver, const crypto::ed25519_public_key &pk_ed, const crypto::x25519_public_key &pk_x2);
 
     // Stores this record in the database.
@@ -515,11 +515,11 @@ namespace service_nodes
     void set_quorum_history_storage(uint64_t hist_size); // 0 = none (default), 1 = unlimited, N = # of blocks
     bool store();
 
-    //TODO: remove after HF17
+    //TODO: remove after HF18
     crypto::hash hash_uptime_proof(const cryptonote::NOTIFY_UPTIME_PROOF::request &proof) const;
 
     /// Record public ip and storage port and add them to the service node list
-    //TODO: remove after HF17
+    //TODO: remove after HF18
     cryptonote::NOTIFY_UPTIME_PROOF::request generate_uptime_proof(uint32_t public_ip,
                                                                    uint16_t storage_port,
                                                                    uint16_t storage_lmq_port,
@@ -527,7 +527,7 @@ namespace service_nodes
     
     uptime_proof::Proof generate_uptime_proof(uint32_t public_ip, uint16_t storage_port, uint16_t storage_lmq_port, std::array<uint16_t, 3> ss_version, uint16_t quorumnet_port, std::array<uint16_t, 3> lokinet_version) const;
 
-    //TODO: remove after HF17
+    //TODO: remove after HF18
     bool handle_uptime_proof(cryptonote::NOTIFY_UPTIME_PROOF::request const &proof, bool &my_uptime_proof_confirmation, crypto::x25519_public_key &x25519_pkey);
 
     bool handle_btencoded_uptime_proof(std::unique_ptr<uptime_proof::Proof> proof, bool &my_uptime_proof_confirmation, crypto::x25519_public_key &x25519_pkey);

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -104,8 +104,8 @@ namespace service_nodes
       checkpoint_participation = proof.checkpoint_participation;
       pulse_participation      = proof.pulse_participation;
 
-      // TODO: remove after HF17
-      if (proof.proof->version >= MIN_TIMESTAMP_VERSION && hf_version >= cryptonote::network_version_17) {
+      // TODO: remove after HF18
+      if (proof.proof->version >= MIN_TIMESTAMP_VERSION && hf_version >= cryptonote::network_version_18) {
         timestamp_participation  = proof.timestamp_participation;
         timesync_status          = proof.timesync_status;
         check_timestamp_obligation = true;

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -224,7 +224,7 @@ namespace service_nodes {
   };
 
   constexpr proof_version MIN_UPTIME_PROOF_VERSIONS[] = {
-    {cryptonote::network_version_17,                      {9,0,0}},
+    {cryptonote::network_version_18,                      {9,0,0}},
     {cryptonote::network_version_16_pulse,                {8,1,0}},
     {cryptonote::network_version_15_lns,                  {7,1,2}},
     {cryptonote::network_version_14_blink,                {6,1,0}},


### PR DESCRIPTION
Hardfork 17 will transition for all users already on 8.x.x

Hardfork 18 to be afterwards with ONS updates, Decommission reasons, btencoded uptime proofs etc