### PR TITLE
Add Dockerfile and build script

### DIFF
--- a/contrib/docker/Dockerfile.oxen-ubuntu
+++ b/contrib/docker/Dockerfile.oxen-ubuntu
@@ -1,0 +1,7 @@
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && apt-get -y install apt-utils ca-certificates
+COPY oxen-deb-key.gpg /etc/apt/trusted.gpg.d/oxen.gpg
+RUN echo "deb https://deb.oxen.io focal main" > /etc/apt/sources.list.d/oxen.list && \
+    apt-get update

--- a/contrib/docker/Dockerfile.oxend
+++ b/contrib/docker/Dockerfile.oxend
@@ -1,0 +1,27 @@
+FROM oxen-ubuntu:20.04
+
+RUN apt-get -y install oxend oxen-wallet-cli
+
+ARG USER_ID
+ARG GROUP_ID
+
+# https://vsupalov.com/docker-shared-permissions/
+# removed due to "addgroup: The GID `100' is already in use"
+# RUN addgroup --gid $GROUP_ID oxen && 
+
+RUN adduser --system --disabled-password --uid $USER_ID --gid $GROUP_ID oxen && \
+    mkdir -p /wallet /home/oxen/.oxen && \
+    chown -R oxen:$GROUP_ID /home/oxen/.oxen && \
+    chown -R oxen:$GROUP_ID /wallet
+
+# Contains the blockchain
+VOLUME /home/oxen/.oxen
+
+EXPOSE 22022
+EXPOSE 22023
+
+# switch to user oxen
+USER oxen
+WORKDIR /home/oxen
+
+ENTRYPOINT ["oxend", "--p2p-bind-ip=0.0.0.0", "--p2p-bind-port=22022", "--rpc-admin=0.0.0.0:22023", "--non-interactive"]

--- a/contrib/docker/README.md
+++ b/contrib/docker/README.md
@@ -1,0 +1,117 @@
+# Dockerfile for end users
+
+For users who take comfort in containerization.
+
+## Benefits
+
+- Distro agnostic: run on any Linux distro with docker installed
+- Security isolation: run untrusted software without fear
+- Resource isolation: run oxend with a specific amount of CPU and memory
+- Simplicity: get up and running with only a few commands
+
+## Quickstart
+
+If you just want to build the container image and get oxend running:
+
+```
+$ sh build_container.sh
+$ docker run -d -p 22022:22022 --name oxend oxend:8.1.6
+```
+
+The blockchain and wallet won't be persisted beyond the containers lifetime, so you probably want to continue reading if
+you want to run the container long-term.
+
+## Usage details
+
+### Building the container
+
+`build_container.sh` builds a Docker container image based on Ubuntu 20.04 using the most-recent oxen pre-compiled binaries.
+The `RELEASE` variable can be updated for any release version. Once built, the container image is stored locally:
+
+```
+$ docker images
+REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
+oxend               8.1.6               d3cafa2081b0        9 days ago          185MB
+```
+
+The image can be used to run the oxend container locally. The image can also be uploaded to a docker registry so that
+other users can use it without needing to build it.
+
+### Run the container
+
+Run the container, storing the blockchain in Docker volume `oxen-blockchain`:
+
+`$ docker run --name oxend -d --mount "source=oxen-blockchain,target=/home/oxen/.oxen,type=volume" oxend:8.1.6`
+
+Same as above, but additionally mounting the wallet directory `/home/<your_user>/Oxen` to `/wallet` in the container:
+
+```
+$ docker run --name oxend -d --mount "source=oxen-blockchain,target=/home/oxen/.oxen,type=volume" \
+                             --mount "source=/home/<your_user>/Oxen,target=/wallet,type=bind" oxend:8.1.6
+```
+
+Check on how the synchronization is going:
+
+```
+$ docker logs oxend
+```
+
+#### Limiting resource usage
+
+On a shared server, it may be useful to limit the amount of resources the oxend container can consume. The recommended minimum
+specs are 4G memory, 2 CPUs, and 30G disk. The memory and CPUs can be limited easily in the `run` command:
+
+```
+$ docker run --name oxend -d --mount "source=oxen-blockchain,target=/home/oxen/.oxen,type=volume" \
+                             --mount "source=/home/<your_user>/Oxen,target=/wallet,type=bind" \
+			     --memory=4g --cpus=2 oxend:8.1.6
+```
+
+Note: the blockchain sync speed will be impacted by limiting the CPU allocation.
+
+The disk capacity is mostly used to store the blockchain. It's large, and will grow (slowly) over time. To prevent it from consuming
+the OS partition, it is a good idea to use a separate partition for `/var/lib/docker`. Many VPS companies allow for attaching
+easily-resizable volumes to a VPS; such a volume can be used to grow the volume as needed.
+
+### Run the wallet CLI
+
+These steps assume the oxend container was started with your walled directory bind mounted to `/wallet` inside the container.
+
+To run against your local oxend:
+
+`$ docker exec -it oxend oxen-wallet-cli --wallet /wallet/wallets/<your_wallet_name>`
+
+To run against a public daemon:
+
+```
+$ docker exec -it oxend oxen-wallet-cli --wallet /wallet/wallets/<your_wallet_name> \
+                                        --daemon-address public.loki.foundation:22023
+```
+
+### Stopping the container
+
+Stop the container from running:
+
+```
+$ docker stop oxend
+```
+
+After the container is no longer running, it can be deleted. Assuming you mounted the `oxen-blockchain` volume, the
+blockchain will *not* be deleted:
+
+```
+$ docker rm oxend
+```
+
+If you add the `--rm` flag to the `docker run` command, then the container will be automatically removed when it is stopped.
+
+### Removing the oxen-blockchain volume
+
+The `oxen-blockchain` volume has its own lifecycle, and can be mounted as newer versions of the container become available.
+However, it can be deleted easily:
+
+```
+$ docker volume rm oxen-blockchain
+```
+
+Remember, you will need to resync the blockchain if you remove the `oxen-blockchain` volume.

--- a/contrib/docker/build_base_container.sh
+++ b/contrib/docker/build_base_container.sh
@@ -1,0 +1,4 @@
+RELEASE=20.04
+curl -so oxen-deb-key.gpg https://deb.oxen.io/pub.gpg
+docker build -t oxen-ubuntu:${RELEASE} -f Dockerfile.oxen-ubuntu .
+rm oxen-deb-key.gpg

--- a/contrib/docker/build_oxend_container.sh
+++ b/contrib/docker/build_oxend_container.sh
@@ -1,0 +1,2 @@
+RELEASE=8.1.6
+docker build -t oxend:${RELEASE} -f Dockerfile.oxend --build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) .


### PR DESCRIPTION
Add a Dockerfile and build script to allow oxend and the CLI wallet to be run inside a container.

My goal was to just get oxend running on my Slackware box, so I could have the CLI wallet run against a local daemon. I opted to go with a Docker container instead of building a Slackware package so that: 1) more than one person may find it useful, and 2) to provide some resource and security isolation.

I intend to build on this to get a fully-containerized service node setup.