### PR TITLE
Disable upnp router poking by default

### DIFF
--- a/src/p2p/net_node.cpp
+++ b/src/p2p/net_node.cpp
@@ -147,8 +147,8 @@ namespace nodetool
     const command_line::arg_descriptor<bool> arg_p2p_hide_my_port   =    {"hide-my-port", "Do not announce yourself as peerlist candidate", false, true};
     const command_line::arg_descriptor<bool> arg_no_sync = {"no-sync", "Don't synchronize the blockchain with other peers", false};
 
-    const command_line::arg_descriptor<bool>        arg_no_igd  = {"no-igd", "Disable UPnP port mapping"};
-    const command_line::arg_descriptor<std::string> arg_igd = {"igd", "UPnP port mapping (disabled, enabled, delayed)", "delayed"};
+    const command_line::arg_descriptor<bool>        arg_no_igd  = {"no-igd", "Backwards compatibility option (this is now the default)"};
+    const command_line::arg_descriptor<std::string> arg_igd = {"igd", "UPnP port mapping (disabled, enabled, delayed)", "disabled"};
     const command_line::arg_descriptor<bool>        arg_p2p_use_ipv6  = {"p2p-use-ipv6", "Enable IPv6 for p2p", false};
     const command_line::arg_descriptor<bool>        arg_p2p_ignore_ipv4  = {"p2p-ignore-ipv4", "Ignore unsuccessful IPv4 bind for p2p", false};
     const command_line::arg_descriptor<int64_t>     arg_out_peers = {"out-peers", "set max number of out peers", -1};

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -372,7 +372,7 @@ namespace nodetool
     }
     else if (sigd == "delayed")
     {
-      if (has_no_igd && !command_line::is_arg_defaulted(vm, arg_igd))
+      if (has_no_igd)
       {
         MFATAL("Cannot have both --" << arg_no_igd.name << " and --" << arg_igd.name << " delayed");
         return false;


### PR DESCRIPTION
It tends to slow down startup/shutdown and probably isn't very useful for Oxen's network (see #1419)

#1419 is about going further, but this is a quick fix for now to just change the default to disabled without removing it.