### PR TITLE
print_sn_status cleanup

### DIFF
--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -1729,16 +1729,16 @@ static void append_printable_service_node_list_entry(cryptonote::network_type ne
     if (entry.earned_downtime_blocks < service_nodes::DECOMMISSION_MINIMUM)
       stream << " (Note: " << service_nodes::DECOMMISSION_MINIMUM << " blocks required to enable deregistration delay)";
   } else if (is_registered) {
-    stream << indent2 << "Current Status: DECOMMISSIONED - " ;
-    auto reason = cryptonote::readable_reasons(entry.last_decommission_reason_consensus_all);
-    if (reason.empty()) // No unanimous reason, fall back to any reasons:
-      reason = cryptonote::readable_reasons(entry.last_decommission_reason_consensus_any);
-    if (reason.empty())
-      stream << "reason(s) not available";
-    for (auto i = reason.begin(); i != reason.end(); ++i)
-    {
-      if (i != reason.begin()) stream << ", ";
-      stream << *i;
+    stream << indent2 << "Current Status: DECOMMISSIONED" ;
+    if (entry.last_decommission_reason_consensus_all || entry.last_decommission_reason_consensus_any)
+      stream << " - ";
+    if (auto reasons = cryptonote::readable_reasons(entry.last_decommission_reason_consensus_all); !reasons.empty())
+      stream << tools::join(", ", reasons);
+    // Add any "any" reasons that aren't in all with a (some) qualifier
+    if (auto reasons = cryptonote::readable_reasons(entry.last_decommission_reason_consensus_any & ~entry.last_decommission_reason_consensus_all); !reasons.empty()) {
+      for (auto& r : reasons)
+        r += "(some)";
+      stream << (entry.last_decommission_reason_consensus_all ? ", " : "") << tools::join(", ", reasons);
     }
     stream << "\n";
     stream << indent2 << "Remaining Decommission Time Until DEREGISTRATION: " << entry.earned_downtime_blocks << " blocks";

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -1693,32 +1693,6 @@ static void append_printable_service_node_list_entry(cryptonote::network_type ne
         << tools::join(".", entry.storage_server_version) << " / " << tools::join(".", entry.lokinet_version) << "\n";
 
     //
-    // NOTE: Node Credits
-    //
-    if (entry.active) {
-      stream << indent2 << "Current Status: ACTIVE\n";
-      stream << indent2 << "Downtime Credits: " << entry.earned_downtime_blocks << " blocks"
-        << " (about " << to_string_rounded(entry.earned_downtime_blocks / (double) BLOCKS_EXPECTED_IN_HOURS(1), 2)  << " hours)";
-      if (entry.earned_downtime_blocks < service_nodes::DECOMMISSION_MINIMUM)
-        stream << " (Note: " << service_nodes::DECOMMISSION_MINIMUM << " blocks required to enable deregistration delay)";
-    } else {
-      stream << indent2 << "Current Status: DECOMMISSIONED - " ;
-      auto reason = cryptonote::readable_reasons(entry.last_decommission_reason_consensus_all);
-      if (reason.empty()) // No unanimous reason, fall back to any reasons:
-        reason = cryptonote::readable_reasons(entry.last_decommission_reason_consensus_any);
-      if (reason.empty())
-        stream << "reason(s) not available";
-      for (auto i = reason.begin(); i != reason.end(); ++i)
-      {
-        if (i != reason.begin()) stream << ", ";
-        stream << *i;
-      }
-      stream << "\n";
-      stream << indent2 << "Remaining Decommission Time Until DEREGISTRATION: " << entry.earned_downtime_blocks << " blocks";
-    }
-    stream << "\n";
-
-    //
     // NOTE: Print Voting History
     //
     stream << indent2 <<  "Checkpoints [Height,Voted]: ";
@@ -1744,6 +1718,34 @@ static void append_printable_service_node_list_entry(cryptonote::network_type ne
       stream << indent3 << "Amount / Reserved: " << cryptonote::print_money(contributor.amount) << "/" << cryptonote::print_money(contributor.reserved) << "\n";
     }
   }
+
+  //
+  // NOTE: Overall status
+  //
+  if (entry.active) {
+    stream << indent2 << "Current Status: ACTIVE\n";
+    stream << indent2 << "Downtime Credits: " << entry.earned_downtime_blocks << " blocks"
+      << " (about " << to_string_rounded(entry.earned_downtime_blocks / (double) BLOCKS_EXPECTED_IN_HOURS(1), 2)  << " hours)";
+    if (entry.earned_downtime_blocks < service_nodes::DECOMMISSION_MINIMUM)
+      stream << " (Note: " << service_nodes::DECOMMISSION_MINIMUM << " blocks required to enable deregistration delay)";
+  } else if (is_registered) {
+    stream << indent2 << "Current Status: DECOMMISSIONED - " ;
+    auto reason = cryptonote::readable_reasons(entry.last_decommission_reason_consensus_all);
+    if (reason.empty()) // No unanimous reason, fall back to any reasons:
+      reason = cryptonote::readable_reasons(entry.last_decommission_reason_consensus_any);
+    if (reason.empty())
+      stream << "reason(s) not available";
+    for (auto i = reason.begin(); i != reason.end(); ++i)
+    {
+      if (i != reason.begin()) stream << ", ";
+      stream << *i;
+    }
+    stream << "\n";
+    stream << indent2 << "Remaining Decommission Time Until DEREGISTRATION: " << entry.earned_downtime_blocks << " blocks";
+  } else {
+      stream << indent2 << "Current Status: awaiting contributions\n";
+  }
+  stream << "\n";
 
   buffer.append(stream.str());
 }

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -1695,15 +1695,19 @@ static void append_printable_service_node_list_entry(cryptonote::network_type ne
     //
     // NOTE: Node Credits
     //
-    stream << indent2;
     if (entry.active) {
-      stream << "Downtime Credits: " << entry.earned_downtime_blocks << " blocks";
-      stream << " (about " << to_string_rounded(entry.earned_downtime_blocks / (double) BLOCKS_EXPECTED_IN_HOURS(1), 2)  << " hours)";
+      stream << indent2 << "Current Status: ACTIVE\n";
+      stream << indent2 << "Downtime Credits: " << entry.earned_downtime_blocks << " blocks"
+        << " (about " << to_string_rounded(entry.earned_downtime_blocks / (double) BLOCKS_EXPECTED_IN_HOURS(1), 2)  << " hours)";
       if (entry.earned_downtime_blocks < service_nodes::DECOMMISSION_MINIMUM)
         stream << " (Note: " << service_nodes::DECOMMISSION_MINIMUM << " blocks required to enable deregistration delay)";
     } else {
-      stream << "Current Status: DECOMMISSIONED - " ;
+      stream << indent2 << "Current Status: DECOMMISSIONED - " ;
       auto reason = cryptonote::readable_reasons(entry.last_decommission_reason_consensus_all);
+      if (reason.empty()) // No unanimous reason, fall back to any reasons:
+        reason = cryptonote::readable_reasons(entry.last_decommission_reason_consensus_any);
+      if (reason.empty())
+        stream << "reason(s) not available";
       for (auto i = reason.begin(); i != reason.end(); ++i)
       {
         if (i != reason.begin()) stream << ", ";


### PR DESCRIPTION
With #1369 the print_sn_status output has grown rather large; this condenses it a bit and rearranges some of it.

(Note: this PR is on top of #1369 -- only the last commits are relevant).