### PR TITLE
Test suite fix for HF18

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1351,6 +1351,7 @@ bool Blockchain::validate_miner_transaction(const block& b, size_t cumulative_bl
   }
 
   block_reward_parts reward_parts;
+
   if (!get_oxen_block_reward(median_weight, cumulative_block_weight, already_generated_coins, version, reward_parts, block_reward_context))
   {
     MERROR_VER("block weight " << cumulative_block_weight << " is bigger than allowed for this blockchain");

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -277,34 +277,32 @@ namespace cryptonote
     keypair const gov_key = get_deterministic_keypair_from_height(height); // NOTE: Always need since we use same key for service node
 
     // NOTE: TX Extra
+    add_tx_extra<tx_extra_pub_key>(tx, txkey.pub);
+    if(!extra_nonce.empty())
     {
-      add_tx_extra<tx_extra_pub_key>(tx, txkey.pub);
-      if(!extra_nonce.empty())
-      {
-        if(!add_extra_nonce_to_tx_extra(tx.extra, extra_nonce))
-          return false;
-      }
-
-      // TODO(doyle): We don't need to do this. It's a deterministic key.
-      if (already_generated_coins != 0)
-        add_tx_extra<tx_extra_pub_key>(tx, gov_key.pub);
-
-      add_service_node_winner_to_tx_extra(tx.extra, miner_tx_context.block_leader.key);
+      if(!add_extra_nonce_to_tx_extra(tx.extra, extra_nonce))
+        return false;
     }
 
-    block_reward_parts reward_parts = {};
-    {
-      oxen_block_reward_context block_reward_context = {};
-      block_reward_context.fee                       = fee;
-      block_reward_context.height                    = height;
-      block_reward_context.block_leader_payouts      = miner_tx_context.block_leader.payouts;
-      block_reward_context.batched_governance        = miner_tx_context.batched_governance;
+    // TODO(doyle): We don't need to do this. It's a deterministic key.
+    if (already_generated_coins != 0)
+      add_tx_extra<tx_extra_pub_key>(tx, gov_key.pub);
 
-      if(!get_oxen_block_reward(median_weight, current_block_weight, already_generated_coins, hard_fork_version, reward_parts, block_reward_context))
-      {
-        LOG_PRINT_L0("Failed to calculate block reward");
-        return false;
-      }
+
+    add_service_node_winner_to_tx_extra(tx.extra, miner_tx_context.block_leader.key);
+
+
+    oxen_block_reward_context block_reward_context = {};
+    block_reward_context.fee                       = fee;
+    block_reward_context.height                    = height;
+    block_reward_context.block_leader_payouts      = miner_tx_context.block_leader.payouts;
+    block_reward_context.batched_governance        = miner_tx_context.batched_governance;
+
+    block_reward_parts reward_parts{};
+    if(!get_oxen_block_reward(median_weight, current_block_weight, already_generated_coins, hard_fork_version, reward_parts, block_reward_context))
+    {
+      LOG_PRINT_L0("Failed to calculate block reward");
+      return false;
     }
 
     // TODO(doyle): Batching awards
@@ -415,7 +413,7 @@ namespace cryptonote
       }
     }
     CHECK_AND_ASSERT_MES(rewards_length <= rewards.size(), false, "More rewards specified than supported, number of rewards: " << rewards_length << ", capacity: " << rewards.size());
-    CHECK_AND_ASSERT_MES(rewards_length > 0,               false, "Zero rewards are to be payed out, there should be atleast 1");
+    CHECK_AND_ASSERT_MES(rewards_length > 0,               false, "Zero rewards are to be payed out, there should be at least 1");
 
     // NOTE: Make TX Outputs
     uint64_t summary_amounts = 0;

--- a/tests/core_tests/chaingen.cpp
+++ b/tests/core_tests/chaingen.cpp
@@ -292,7 +292,7 @@ bool oxen_chain_generator::add_blocks_until_next_checkpointable_height()
     return false;
 
   // NOTE: Add blocks until we get to the first height that has a checkpointing
-  // quorum AND there are service nodes in the quorum. Note we do this naiively
+  // quorum AND there are service nodes in the quorum. Note we do this naively
   // as tests shouldn't have to care about implementation details.
   for (;;)
   {
@@ -900,8 +900,8 @@ bool oxen_chain_generator::block_begin(oxen_blockchain_entry &entry, oxen_create
   }
 
   // NOTE: Calculate governance
-  cryptonote::oxen_miner_tx_context miner_tx_context = {};
-  service_nodes::quorum pulse_quorum                 = {};
+  cryptonote::oxen_miner_tx_context miner_tx_context;
+  service_nodes::quorum pulse_quorum;
   std::vector<service_nodes::pubkey_and_sninfo> active_snode_list =
       params.prev.service_node_state.active_service_nodes_infos();
 
@@ -948,11 +948,13 @@ bool oxen_chain_generator::block_begin(oxen_blockchain_entry &entry, oxen_create
     constexpr uint64_t num_blocks       = cryptonote::get_config(cryptonote::FAKECHAIN).GOVERNANCE_REWARD_INTERVAL_IN_BLOCKS;
     uint64_t start_height               = height - num_blocks;
 
+    static_assert(cryptonote::network_version_count == cryptonote::network_version_18 + 1,
+            "The code below needs to be updated to support higher hard fork versions");
     if (blk.major_version == cryptonote::network_version_15_lns)
       miner_tx_context.batched_governance = FOUNDATION_REWARD_HF15 * num_blocks;
     else if (blk.major_version == cryptonote::network_version_16_pulse)
       miner_tx_context.batched_governance = (FOUNDATION_REWARD_HF15 + CHAINFLIP_LIQUIDITY_HF16) * num_blocks;
-    else if (blk.major_version == cryptonote::network_version_17)
+    else if (blk.major_version >= cryptonote::network_version_17 && blk.major_version <= cryptonote::network_version_18)
       miner_tx_context.batched_governance = FOUNDATION_REWARD_HF17 * num_blocks;
     else
     {


### PR DESCRIPTION
Governance reward calculations were hard-coded for == HF17 rather than >= 17, so for HF18 it was falling back to the old "add up all the values" method that we used to use.  Updated it to support HF18, and add a static_assert that will fail to compile (without a fix) when we add HF19.

Also some minor cleanups (mostly indent changes for unnecessary blocks -- ignore whitespace when looking at the diff).