### PR TITLE
reduce fees

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -69,10 +69,10 @@ static_assert(STAKING_PORTIONS % 12 == 0, "Use a multiple of twelve, so that it 
 #define CRYPTONOTE_COINBASE_BLOB_RESERVED_SIZE          600
 #define CRYPTONOTE_DISPLAY_DECIMAL_POINT                9
 
-#define FEE_PER_KB                                      ((uint64_t)2000000000) // 2 OXEN (= 2 * pow(10, 9))
-#define FEE_PER_BYTE                                    ((uint64_t)215)   // Fallback used in wallet if no fee is available from RPC
-#define FEE_PER_BYTE_V12                                ((uint64_t)17200) // Higher fee (and fallback) in v12 (only, v13 switches back)
-#define FEE_PER_OUTPUT                                  ((uint64_t)20000000) // 0.02 OXEN per tx output (in addition to the per-byte fee), starting in v13
+#define FEE_PER_BYTE_V12                                ((uint64_t)17200) // Higher fee in v12 (only, v13 switches back)
+#define FEE_PER_BYTE_V13                                ((uint64_t)215)   // Fallback used in wallet if no fee is available from RPC
+#define FEE_PER_OUTPUT_V13                              ((uint64_t)20000000) // 0.02 OXEN per tx output (in addition to the per-byte fee), starting in v13
+#define FEE_PER_OUTPUT_V18                              ((uint64_t)5000000) // 0.005 OXEN per tx output (in addition to the per-byte fee), starting in v18
 #define DYNAMIC_FEE_PER_KB_BASE_BLOCK_REWARD            ((uint64_t)10000000000000) // 10 * pow(10,12)
 #define DYNAMIC_FEE_PER_KB_BASE_FEE_V5                  ((uint64_t)400000000)
 #define DYNAMIC_FEE_REFERENCE_TRANSACTION_WEIGHT        ((uint64_t)3000)

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3711,8 +3711,10 @@ byte_and_output_fees Blockchain::get_dynamic_base_fee(uint64_t block_reward, siz
     assert(hi == 0);
     lo /= 5;
 
-    if (version >= HF_VERSION_PER_OUTPUT_FEE)
-      fees.second = FEE_PER_OUTPUT;
+    if (version >= cryptonote::network_version_18)
+      fees.second = FEE_PER_OUTPUT_V18;
+    else if (version >= HF_VERSION_PER_OUTPUT_FEE)
+      fees.second = FEE_PER_OUTPUT_V13;
 
     return fees;
   }

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -89,7 +89,13 @@ namespace cryptonote
       o.do_not_relay = !approved;
       o.approved_blink = approved;
       o.fee_percent = BLINK_MINER_TX_FEE_PERCENT;
-      o.burn_percent = hf_version <= network_version_14_blink ? BLINK_BURN_TX_FEE_PERCENT_OLD : BLINK_BURN_TX_FEE_PERCENT;
+
+      if (hf_version >= network_version_18)
+        o.burn_percent = BLINK_BURN_TX_FEE_PERCENT_V18;
+      //TODO remove this in HF19
+      else
+        o.burn_percent = BLINK_BURN_TX_FEE_PERCENT_V15;
+
       o.burn_fixed = BLINK_BURN_FIXED;
       return o;
     }

--- a/src/oxen_economy.h
+++ b/src/oxen_economy.h
@@ -79,6 +79,7 @@ constexpr uint64_t burn_needed(uint8_t hf_version, mapping_type type)
 
   // The base amount for session/wallet/lokinet-1year:
   const uint64_t basic_fee = (
+      hf_version >= 18 ? 7*COIN :  // cryptonote::network_version_18
       hf_version >= 16 ? 15*COIN :  // cryptonote::network_version_16_pulse -- but don't want to add cryptonote_config.h include
       20*COIN                       // cryptonote::network_version_15_ons
   );

--- a/src/oxen_economy.h
+++ b/src/oxen_economy.h
@@ -41,16 +41,12 @@ static_assert(                           SN_REWARD_HF15 + FOUNDATION_REWARD_HF17
 // and the miner including the tx includes MINER_TX_FEE_PERCENT * [minimum tx fee]; the rest must be left unclaimed.
 constexpr uint64_t BLINK_MINER_TX_FEE_PERCENT = 100; // The blink miner tx fee (as a percentage of the minimum tx fee)
 constexpr uint64_t BLINK_BURN_FIXED           = 0;  // A fixed amount (in atomic currency units) that the sender must burn
-constexpr uint64_t BLINK_BURN_TX_FEE_PERCENT  = 150; // A percentage of the minimum miner tx fee that the sender must burn.  (Adds to BLINK_BURN_FIXED)
-
-// FIXME: can remove this post-fork 15; the burned amount only matters for mempool acceptance and
-// blink quorum signing, but isn't part of the blockchain concensus rules (so we don't actually have
-// to keep it around in the code for syncing the chain).
-constexpr uint64_t BLINK_BURN_TX_FEE_PERCENT_OLD = 400; // A percentage of the minimum miner tx fee that the sender must burn.  (Adds to BLINK_BURN_FIXED)
+constexpr uint64_t BLINK_BURN_TX_FEE_PERCENT_V15  = 150; // A percentage of the minimum miner tx fee that the sender must burn.  (Adds to BLINK_BURN_FIXED)
+constexpr uint64_t BLINK_BURN_TX_FEE_PERCENT_V18  = 200; // A percentage of the minimum miner tx fee that the sender must burn.  (Adds to BLINK_BURN_FIXED)
 
 static_assert(BLINK_MINER_TX_FEE_PERCENT >= 100, "blink miner fee cannot be smaller than the base tx fee");
 static_assert(BLINK_BURN_FIXED >= 0, "fixed blink burn amount cannot be negative");
-static_assert(BLINK_BURN_TX_FEE_PERCENT >= 0, "blink burn tx percent cannot be negative");
+static_assert(BLINK_BURN_TX_FEE_PERCENT_V18 >= 0, "blink burn tx percent cannot be negative");
 
 // -------------------------------------------------------------------------------------------------
 //

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2376,7 +2376,7 @@ namespace cryptonote { namespace rpc {
     res.fee_per_byte = fees.first;
     res.fee_per_output = fees.second;
     res.blink_fee_fixed = BLINK_BURN_FIXED;
-    constexpr auto blink_percent = BLINK_MINER_TX_FEE_PERCENT + BLINK_BURN_TX_FEE_PERCENT;
+    constexpr auto blink_percent = BLINK_MINER_TX_FEE_PERCENT + BLINK_BURN_TX_FEE_PERCENT_V18;
     res.blink_fee_per_byte = res.fee_per_byte * blink_percent / 100;
     res.blink_fee_per_output = res.fee_per_output * blink_percent / 100;
     res.quantization_mask = Blockchain::get_fee_quantization_mask();

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1661,7 +1661,7 @@ private:
     bool m_light_wallet; /* sends view key to daemon for scanning */
     uint64_t m_light_wallet_scanned_block_height;
     uint64_t m_light_wallet_blockchain_height;
-    uint64_t m_light_wallet_per_kb_fee = FEE_PER_KB;
+    uint64_t m_light_wallet_per_kb_fee = FEE_PER_BYTE_V13 * 1024;
     bool m_light_wallet_connected;
     uint64_t m_light_wallet_balance;
     uint64_t m_light_wallet_unlocked_balance;


### PR DESCRIPTION
Reduces fees for the upcoming HF

- FEE_PER_BYTE kept same at 215 (Oxen atomic units)
- FEE_PER_OUTPUT dropped from 20,000,000 to 5,000,000 (Oxen atomic units) or 0.02 Oxen to 0.005 Oxen
- BLINK_BURN_TX_FEE_PERCENT increased from 150% to 200%

Should result in a USD fee per transaction of 2c for regular transaction and 6c for blink (At current prices of $1.80)