### PR TITLE
Swarm id fix

### DIFF
--- a/src/cryptonote_core/service_node_swarm.cpp
+++ b/src/cryptonote_core/service_node_swarm.cpp
@@ -22,7 +22,7 @@ namespace service_nodes
       all_ids.push_back(entry.first);
     }
 
-    std::sort(all_ids.begin(), all_ids.end());
+    assert(std::is_sorted(all_ids.begin(), all_ids.end()));
 
     uint64_t max_dist = 0;
     // The new swarm that is the farthest from its right neighbour

--- a/src/cryptonote_core/service_node_swarm.cpp
+++ b/src/cryptonote_core/service_node_swarm.cpp
@@ -12,13 +12,9 @@
 
 namespace service_nodes
 {
-  static uint64_t get_new_swarm_id(const swarm_snode_map_t &swarm_to_snodes)
+  uint64_t get_new_swarm_id(const swarm_snode_map_t &swarm_to_snodes)
   {
-    // UINT64_MAX is reserved for unassigned swarms
-    constexpr uint64_t MAX_ID = UINT64_MAX - 1;
-
     if (swarm_to_snodes.empty()) return 0;
-    if (swarm_to_snodes.size() == 1) return MAX_ID / 2;
 
     std::vector<swarm_id_t> all_ids;
     all_ids.reserve(swarm_to_snodes.size());
@@ -158,8 +154,15 @@ namespace service_nodes
         remove_excess_snode_from_swarm(random_excess_snode, swarm_to_snodes);
       }
       const auto new_swarm_id = get_new_swarm_id(swarm_to_snodes);
-      swarm_to_snodes.insert({new_swarm_id, std::move(new_swarm_snodes)});
-      LOG_PRINT_L2("Created new swarm from excess: " << new_swarm_id);
+      if (auto [it, ins] = swarm_to_snodes.emplace(new_swarm_id, std::move(new_swarm_snodes));
+              !ins) {
+          MFATAL("New swarm ID gave a swarm id (" << new_swarm_id << ") that already exists -- this is a bug!");
+          // If we actually abort() here then hitting this would potentially kill the whole network
+          // if we hit this bug, so just warn very loudly and move on; if it happens we'll have to
+          // track down the bug and fix it separately.
+      } else {
+          LOG_PRINT_L2("Created new swarm from excess: " << new_swarm_id);
+      }
     }
   }
 

--- a/src/cryptonote_core/service_node_swarm.h
+++ b/src/cryptonote_core/service_node_swarm.h
@@ -7,6 +7,8 @@
 #include <random>
 
 namespace service_nodes {
+    inline constexpr uint64_t MAX_ID = UNASSIGNED_SWARM_ID - 1;
+
     using swarm_snode_map_t = std::map<swarm_id_t, std::vector<crypto::public_key>>;
     struct swarm_size {
         swarm_id_t swarm_id;
@@ -16,6 +18,8 @@ namespace service_nodes {
         crypto::public_key public_key;
         swarm_id_t swarm_id;
     };
+
+    uint64_t get_new_swarm_id(const swarm_snode_map_t& swarm_to_snodes);
 
     void calc_swarm_changes(swarm_snode_map_t& swarm_to_snodes, uint64_t seed);
 

--- a/tests/unit_tests/service_nodes_swarm.cpp
+++ b/tests/unit_tests/service_nodes_swarm.cpp
@@ -542,6 +542,15 @@ TEST(swarm_to_snodes, unassigned_swarm_bug)
   EXPECT_NE(e, b);
   EXPECT_EQ(e, MAX_ID);
 
+  // Try some other random starting points and make sure we get something halfway around:
+  swarms.clear();
+  swarms.emplace(MAX_ID/4, empty_swarm);
+  EXPECT_EQ(get_new_swarm_id(swarms), MAX_ID/2 + MAX_ID/4);
+
+  swarms.clear();
+  swarms.emplace(12345678901234567890ULL, empty_swarm);
+  EXPECT_EQ(get_new_swarm_id(swarms), 12345678901234567890ULL - MAX_ID/2 - 1);
+
   // Insert a couple values that straddle the midpoint so that the midpoint of the longest gap will
   // be at the wraparound point:
   swarms.clear();


### PR DESCRIPTION
Fixes #1437 

The important part here is removing this line:
```C++
    if (swarm_to_snodes.size() == 1) return MAX_ID / 2;
```
because, if we end up in a case where we have only one swarm and it *already* has that ID (e.g. create 2, which will be [MAX/2,0] then drop 0) then this returns a swarm_id that already exists, which is bad because then we fail to insert the new swarm, a service node gets left with an unassigned swarm id, and that then causes issues in SS because that node thinks it is deactivated because it doesn't have a swarm id (yet it *is* in the active nodes list, so other network members still try to talk to it).

The condition seems unnecessary (and added a unit test to verify this): *if* the first swarm added is 0, then the following algorithm *already* calculates MAX_ID/2 as a new swarm id, so the special case seems unnecessary to preserve potential swarm id sequences.

Also adds a bunch of unit tests around swarm_id to make sure edge cases are working (they are) and to make sure that generation fits an expected generation pattern for a deterministic random sequence.