### PR TITLE
Add warning if restoring an ed25519 key to a file name .../key

### DIFF
--- a/src/blockchain_utilities/sn_key_tool.cpp
+++ b/src/blockchain_utilities/sn_key_tool.cpp
@@ -308,6 +308,15 @@ int restore(bool ed25519, std::list<std::string_view> args) {
             return error(2, "Derived pubkey (" + oxenmq::to_hex(pubkey.begin(), pubkey.end()) + ") doesn't match "
                     "provided pubkey (" + oxenmq::to_hex(pubkey_expected->begin(), pubkey_expected->end()) + ")");
     } else {
+
+        if (ed25519 && filename.size() >= 4 && filename.substr(filename.size() - 4) == "/key") {
+            std::cout << "\n\n\x1b[31;1m"
+                "Warning: You are trying to restore a file named 'key' using the 'restore'\n"
+                "command, which is intended for the key_ed25519 key file; for old service nodes\n"
+                "with both key files you want to use 'restore-legacy' to restore the old\n"
+                "(pre-Loki 8.x) pubkey.\x1b[0m\n";
+        }
+
         std::cout << "\nIs this correct?  Press Enter to continue, Ctrl-C to cancel.\n";
         std::cin.getline(buf, 129);
         if (!std::cin.good())


### PR DESCRIPTION
A couple people have messaged me now because they tried transferring
keys and used the `restore` command on their legacy `key` file, but it
restored an ed25519 key.

This adds a red warning if attempting to restore an ed key to a filename
ending in `/key` with a note about probably wanting the restore-legacy
command instead.