### PR TITLE
Fixes testnet sync problem caused by retroactivitly dropping the ONS fees

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -372,7 +372,7 @@ bool Blockchain::load_missing_blocks_into_oxen_subsystems()
 
         if (!m_service_node_list.block_added(blk, txs, checkpoint_ptr))
         {
-          MERROR("Unable to process block for updating service node list: " << cryptonote::get_block_hash(blk));
+          MFATAL("Unable to process block for updating service node list: " << cryptonote::get_block_hash(blk));
           return false;
         }
         snl_iteration_duration += clock::now() - snl_start;
@@ -383,7 +383,7 @@ bool Blockchain::load_missing_blocks_into_oxen_subsystems()
         auto ons_start = clock::now();
         if (!m_ons_db.add_block(blk, txs))
         {
-          MERROR("Unable to process block for updating ONS DB: " << cryptonote::get_block_hash(blk));
+          MFATAL("Unable to process block for updating ONS DB: " << cryptonote::get_block_hash(blk));
           return false;
         }
         ons_iteration_duration += clock::now() - ons_start;
@@ -543,12 +543,12 @@ bool Blockchain::init(BlockchainDB* db, sqlite3 *ons_db, const network_type nett
       // so we re-throw
       catch (const std::exception& e)
       {
-        MERROR("Error popping block from blockchain: " << e.what());
+        MFATAL("Error popping block from blockchain: " << e.what());
         throw;
       }
       catch (...)
       {
-        MERROR("Error popping block from blockchain, throwing!");
+        MFATAL("Error popping block from blockchain, throwing!");
         throw;
       }
     }
@@ -574,7 +574,7 @@ bool Blockchain::init(BlockchainDB* db, sqlite3 *ons_db, const network_type nett
 
   if (ons_db && !m_ons_db.init(this, nettype, ons_db))
   {
-    MERROR("ONS failed to initialise");
+    MFATAL("ONS failed to initialise");
     return false;
   }
 
@@ -585,7 +585,7 @@ bool Blockchain::init(BlockchainDB* db, sqlite3 *ons_db, const network_type nett
 
   if (!m_db->is_read_only() && !load_missing_blocks_into_oxen_subsystems())
   {
-    MERROR("Failed to load blocks into oxen subsystems");
+    MFATAL("Failed to load blocks into oxen subsystems");
     return false;
   }
 

--- a/src/cryptonote_core/oxen_name_system.cpp
+++ b/src/cryptonote_core/oxen_name_system.cpp
@@ -1258,6 +1258,13 @@ bool name_system_db::validate_ons_tx(uint8_t hf_version, uint64_t blockchain_hei
   {
     uint64_t burn                = cryptonote::get_burned_amount_from_tx_extra(tx.extra);
     uint64_t const burn_required = (ons_extra.is_buying() || ons_extra.is_renewing()) ? burn_needed(hf_version, ons_extra.type) : 0;
+    if (hf_version == cryptonote::network_version_18 && burn > burn_required && blockchain_height < 524'000) {
+        // Testnet sync fix: PR #1433 merged that lowered fees for HF18 while testnet was already on
+        // HF18, but broke syncing because earlier HF18 blocks have ONS txes at the higher fees, so
+        // this allows them to pass by pretending the tx burned the right amount.
+        burn = burn_required;
+    }
+
     if (burn != burn_required)
     {
       char const *over_or_under = burn > burn_required ? "too much " : "insufficient ";

--- a/src/cryptonote_core/oxen_name_system.cpp
+++ b/src/cryptonote_core/oxen_name_system.cpp
@@ -2095,7 +2095,7 @@ bool name_system_db::add_block(const cryptonote::block &block, const std::vector
       std::string fail_reason;
       if (!validate_ons_tx(block.major_version, height, tx, entry, &fail_reason))
       {
-        LOG_PRINT_L0("ONS TX: Failed to validate for tx=" << get_transaction_hash(tx) << ". This should have failed validation earlier reason=" << fail_reason);
+        MFATAL("ONS TX: Failed to validate for tx=" << get_transaction_hash(tx) << ". This should have failed validation earlier reason=" << fail_reason);
         assert("Failed to validate acquire name service. Should already have failed validation prior" == nullptr);
         return false;
       }

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1609,7 +1609,7 @@ namespace service_nodes
         std::shared_ptr<const quorum> quorum = get_quorum(quorum_type::pulse, block_height, false, nullptr);
         if (!quorum || quorum->validators.empty())
         {
-          MERROR("Unexpected Pulse error " << (quorum ? " quorum was not generated" : " quorum was empty"));
+          MFATAL("Unexpected Pulse error " << (quorum ? " quorum was not generated" : " quorum was empty"));
           return false;
         }
 


### PR DESCRIPTION
The newly merged fees apply retroactively back to the beginning of HF18, but we have older high ONS fee txes there that broke things.  This adds a fix for testnet, and increases some log severities leading to the failing check.

(This wouldn't happen on mainnet because on mainnet the fees properly change *at* the fork, not during it).