### PR TITLE
Creates a new ons pay_type for show_transfers

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -8548,6 +8548,7 @@ bool simple_wallet::show_transfers(const std::vector<std::string> &args_)
         case wallet::pay_type::miner:        color = epee::console_color_cyan; break;
         case wallet::pay_type::governance:   color = epee::console_color_cyan; break;
         case wallet::pay_type::stake:        color = epee::console_color_blue; break;
+        case wallet::pay_type::ons:          color = epee::console_color_blue; break;
         case wallet::pay_type::service_node: color = epee::console_color_cyan; break;
         default:                            color = epee::console_color_magenta; break;
       }
@@ -8568,6 +8569,7 @@ bool simple_wallet::show_transfers(const std::vector<std::string> &args_)
         if (transfer.pay_type == wallet::pay_type::in ||
             transfer.pay_type == wallet::pay_type::governance ||
             transfer.pay_type == wallet::pay_type::service_node ||
+            transfer.pay_type == wallet::pay_type::ons ||
             transfer.pay_type == wallet::pay_type::miner)
           destinations += output.address.substr(0, 6);
         else

--- a/src/wallet/transfer_view.h
+++ b/src/wallet/transfer_view.h
@@ -32,6 +32,7 @@
 #include <string>
 #include <vector>
 #include "cryptonote_basic/subaddress_index.h"
+#include "cryptonote_basic/cryptonote_basic.h"
 #include "transfer_destination.h"
 #include "crypto/hash.h"
 
@@ -45,7 +46,8 @@ enum struct pay_type
   stake,
   miner,
   service_node,
-  governance
+  governance,
+  ons
 };
 
 inline const char *pay_type_string(pay_type type)
@@ -56,10 +58,21 @@ inline const char *pay_type_string(pay_type type)
     case pay_type::in:           return "in";
     case pay_type::out:          return "out";
     case pay_type::stake:        return "stake";
-    case pay_type::miner:        return "miner";
+    case pay_type::ons:          return "ons";
+    case pay_type::miner:        return "reward";
     case pay_type::service_node: return "snode";
     case pay_type::governance:   return "gov";
     default: assert(false);      return "xxxxx";
+  }
+}
+
+inline pay_type pay_type_from_tx(const cryptonote::transaction tx)
+{
+  switch(tx.type)
+  {
+    case cryptonote::txtype::stake: return wallet::pay_type::stake;
+    case cryptonote::txtype::oxen_name_system: return wallet::pay_type::ons;
+    default: return wallet::pay_type::out;
   }
 }
 

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -787,6 +787,7 @@ private:
       bool in = false;
       bool out = false;
       bool stake = false;
+      bool ons = false;
       bool pending = false;
       bool failed = false;
       bool pool = false;

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -2017,7 +2017,7 @@ namespace tools
       {
         res.in.push_back(std::move(entry));
       }
-      else if (entry.pay_type == wallet::pay_type::out || entry.pay_type == wallet::pay_type::stake)
+      else if (entry.pay_type == wallet::pay_type::out || entry.pay_type == wallet::pay_type::stake || entry.pay_type == wallet::pay_type::ons)
       {
         res.out.push_back(std::move(entry));
       }


### PR DESCRIPTION
The displaying of ONS transactions in show_transfers and
export_transfers previously showed the dummy destination address which
contained zero bytes and converted to a nonsense address. Created a new
ONS type for the display functions and removed the displaying of the destination
address.

In addition refactored how we determine that a transaction was either a
staking, ons or output transaction as we were previously parsing the
tx_extra where the data was already in the
cryptonote::transaction::type.

Finally renamed the wording for staking rewards. Previously "miner" now
"reward"