### PR TITLE
Fix SN info upgrade in debug build

### DIFF
--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -3335,6 +3335,11 @@ namespace service_nodes
         info.pulse_sorter = {};
         info.version      = version_t::v6_reassign_sort_keys;
       }
+      if (info.version < version_t::v7_decommission_reason)
+      {
+        // Nothing to do here (leave consensus reasons as 0s)
+        info.version = version_t::v7_decommission_reason;
+      }
       // Make sure we handled any future state version upgrades:
       assert(info.version == tools::enum_top<decltype(info.version)>);
       service_nodes_infos.emplace(std::move(pubkey_info.pubkey), std::move(pubkey_info.info));


### PR DESCRIPTION
The v7 info doesn't need anything done, but it fails the assert() here for a debug build.