### PR TITLE
9.1.2 hotfix -- fix proofs for older nodes with both pubkeys

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ message(STATUS "CMake version ${CMAKE_VERSION}")
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.12 CACHE STRING "macOS deployment target (Apple clang only)")
 
 project(oxen
-    VERSION 9.1.0
+    VERSION 9.1.2
     LANGUAGES CXX C)
 set(OXEN_RELEASE_CODENAME "Audacious Aurochs")
 

--- a/src/cryptonote_core/uptime_proof.cpp
+++ b/src/cryptonote_core/uptime_proof.cpp
@@ -121,7 +121,9 @@ oxenmq::bt_dict Proof::bt_encode_uptime_proof() const
     {"lv", oxenmq::bt_list{{lokinet_version[0], lokinet_version[1], lokinet_version[2]}}},
   };
 
-  if (pubkey != pubkey_ed25519) encoded_proof["pk"] = tools::view_guts(pubkey);
+  if (tools::view_guts(pubkey) != tools::view_guts(pubkey_ed25519)) {
+    encoded_proof["pk"] = tools::view_guts(pubkey);
+  }
 
   return encoded_proof;
 }


### PR DESCRIPTION
(This is already rush-pushed directly to `stable` to get a 9.1.2 build out ASAP)

bt-encoded proofs have a bug for nodes with different legacy/ed25519 pubkeys that isn't easily solvable (it needs a fix on *both* sender and receiver ends).  That fix is in here (in uptime_proof.cpp) but that isn't enough to solve it immediately.

This works around the issue by submitting old-style proofs if we are a node with different legacy/ed25519 pubkeys.