### PR TITLE
ONS backup owner lookup fixes

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -3549,13 +3549,18 @@ namespace cryptonote { namespace rpc {
     std::vector<ons::mapping_record> records = db.get_mappings_by_owners(owners, height);
     for (auto &record : records)
     {
-      auto& entry = res.entries.emplace_back();
-
-      auto it = owner_to_request_index.find(record.owner);
+      auto it = owner_to_request_index.end();
+      if (record.owner)
+          it = owner_to_request_index.find(record.owner);
+      if (it == owner_to_request_index.end() && record.backup_owner)
+          it = owner_to_request_index.find(record.backup_owner);
       if (it == owner_to_request_index.end())
-        throw rpc_error{ERROR_INTERNAL, "Owner=" + record.owner.to_string(nettype()) +
-          ", could not be mapped back a index in the request 'entries' array"};
+        throw rpc_error{ERROR_INTERNAL,
+            (record.owner ? ("Owner=" + record.owner.to_string(nettype()) + " ") : ""s) +
+            (record.backup_owner ? ("BackupOwner=" + record.backup_owner.to_string(nettype()) + " ") : ""s) +
+            " could not be mapped back a index in the request 'entries' array"};
 
+      auto& entry = res.entries.emplace_back();
       entry.request_index   = it->second;
       entry.type            = record.type;
       entry.name_hash       = std::move(record.name_hash);

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -7068,17 +7068,6 @@ bool simple_wallet::ons_by_owner(const std::vector<std::string>& args)
     auto const &rpc = rpc_results[i];
     for (auto const &entry : rpc)
     {
-      std::string const *owner = nullptr;
-      try
-      {
-        owner = &requests[i].entries.at(entry.request_index);
-      }
-      catch (std::exception const &e)
-      {
-        fail_msg_writer() << "Daemon returned an invalid owner index = " << entry.request_index << " skipping mapping";
-        continue;
-      }
-
       std::string_view name;
       std::string value;
       if (auto got = cache.find(entry.name_hash); got != cache.end())
@@ -7100,7 +7089,7 @@ bool simple_wallet::ons_by_owner(const std::vector<std::string>& args)
       if (!value.empty()) writer
         << "\n    Value: " << value;
       writer
-        << "\n    Owner: " << *owner;
+        << "\n    Owner: " << entry.owner;
       if (entry.backup_owner) writer
         << "\n    Backup owner: " << *entry.backup_owner;
       writer


### PR DESCRIPTION
Fixes some issues with listing ONS registrations by owner when the given owner is an ONS entry backup owner.  The RPC call would fail (because it only considered the primary owner instead of both owners).  Fixing that revealed another bug in the cli wallet that it would overwrite the `Owner` value that it displays with the backup owner when one of the returned records is a backup-owned record, rather than showing the proper primary Owner.

(Thanks to @Lucifer1903 for the bug report).