### PR TITLE
Allow HF18 to be used earlier

### DIFF
--- a/src/cryptonote_basic/hardfork.cpp
+++ b/src/cryptonote_basic/hardfork.cpp
@@ -121,7 +121,7 @@ get_hard_fork_heights(network_type nettype, uint8_t version) {
       if (found.first) // Found something suitable in the previous iteration, so one before this hf is the max
         found.second = it->height - 1;
       break;
-    } else if (it->version == version) {
+    } else if (it->version == version && !found.first) {
       found.first = it->height;
     }
   }

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -7783,7 +7783,7 @@ uint64_t wallet2::get_fee_percent(uint32_t priority, txtype type) const
       THROW_WALLET_EXCEPTION(error::invalid_priority);
 
     uint64_t burn_pct = 0;
-    if (use_fork_rules(network_version_18, 0))
+    if (use_fork_rules(network_version_18, 4000))
       burn_pct = BLINK_BURN_TX_FEE_PERCENT_V18;
     else
       THROW_WALLET_EXCEPTION(error::invalid_priority);

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -7783,6 +7783,9 @@ uint64_t wallet2::get_fee_percent(uint32_t priority, txtype type) const
       THROW_WALLET_EXCEPTION(error::invalid_priority);
 
     uint64_t burn_pct = 0;
+    // v9.2.0 introduced minor versions to forks, this use_fork_rules(18,0) will return the height
+    // for HF18.1 when we want 18.0. Workaround this by allowing the use of 18 fork rules 4000
+    // blocks before 18.1
     if (use_fork_rules(network_version_18, 4000))
       burn_pct = BLINK_BURN_TX_FEE_PERCENT_V18;
     else


### PR DESCRIPTION
The get earliest version returns HF 18.1 and this means that our blink
fees that were enabled in HF18 are no longer accepted. Push through to
allow the fees to be used 4000 blocks earlier (current height)