### PR TITLE
Fix missing logger rebrand updates

### DIFF
--- a/contrib/epee/include/epee/console_handler.h
+++ b/contrib/epee/include/epee/console_handler.h
@@ -48,8 +48,8 @@
 #endif
 #include "readline_suspend.h"
 
-#undef MONERO_DEFAULT_LOG_CATEGORY
-#define MONERO_DEFAULT_LOG_CATEGORY "console_handler"
+#undef OXEN_DEFAULT_LOG_CATEGORY
+#define OXEN_DEFAULT_LOG_CATEGORY "console_handler"
 
 namespace epee
 {

--- a/contrib/epee/include/epee/misc_log_ex.h
+++ b/contrib/epee/include/epee/misc_log_ex.h
@@ -34,14 +34,14 @@
 
 #include "easylogging++.h"
 
-#undef LOKI_DEFAULT_LOG_CATEGORY
-#define LOKI_DEFAULT_LOG_CATEGORY "default"
+#undef OXEN_DEFAULT_LOG_CATEGORY
+#define OXEN_DEFAULT_LOG_CATEGORY "default"
 
 #define MAX_LOG_FILE_SIZE 104850000 // 100 MB - 7600 bytes
 #define MAX_LOG_FILES 50
 
 #define CLOG_ENABLED(level, cat) ELPP->vRegistry()->allowed(el::Level::level, cat)
-#define LOG_ENABLED(level) CLOG_ENABLED(level, LOKI_DEFAULT_LOG_CATEGORY)
+#define LOG_ENABLED(level) CLOG_ENABLED(level, OXEN_DEFAULT_LOG_CATEGORY)
 
 #define MCLOG_TYPE(level, cat, type, x) do { \
     if (ELPP->vRegistry()->allowed(level, cat)) { \
@@ -67,20 +67,20 @@
 #define MCLOG_MAGENTA(level,cat,x) MCLOG_COLOR(level,cat,"35",x)
 #define MCLOG_CYAN(level,cat,x) MCLOG_COLOR(level,cat,"36",x)
 
-#define MLOG_RED(level,x) MCLOG_RED(level,LOKI_DEFAULT_LOG_CATEGORY,x)
-#define MLOG_GREEN(level,x) MCLOG_GREEN(level,LOKI_DEFAULT_LOG_CATEGORY,x)
-#define MLOG_YELLOW(level,x) MCLOG_YELLOW(level,LOKI_DEFAULT_LOG_CATEGORY,x)
-#define MLOG_BLUE(level,x) MCLOG_BLUE(level,LOKI_DEFAULT_LOG_CATEGORY,x)
-#define MLOG_MAGENTA(level,x) MCLOG_MAGENTA(level,LOKI_DEFAULT_LOG_CATEGORY,x)
-#define MLOG_CYAN(level,x) MCLOG_CYAN(level,LOKI_DEFAULT_LOG_CATEGORY,x)
+#define MLOG_RED(level,x) MCLOG_RED(level,OXEN_DEFAULT_LOG_CATEGORY,x)
+#define MLOG_GREEN(level,x) MCLOG_GREEN(level,OXEN_DEFAULT_LOG_CATEGORY,x)
+#define MLOG_YELLOW(level,x) MCLOG_YELLOW(level,OXEN_DEFAULT_LOG_CATEGORY,x)
+#define MLOG_BLUE(level,x) MCLOG_BLUE(level,OXEN_DEFAULT_LOG_CATEGORY,x)
+#define MLOG_MAGENTA(level,x) MCLOG_MAGENTA(level,OXEN_DEFAULT_LOG_CATEGORY,x)
+#define MLOG_CYAN(level,x) MCLOG_CYAN(level,OXEN_DEFAULT_LOG_CATEGORY,x)
 
-#define MFATAL(x) MCFATAL(LOKI_DEFAULT_LOG_CATEGORY,x)
-#define MERROR(x) MCERROR(LOKI_DEFAULT_LOG_CATEGORY,x)
-#define MWARNING(x) MCWARNING(LOKI_DEFAULT_LOG_CATEGORY,x)
-#define MINFO(x) MCINFO(LOKI_DEFAULT_LOG_CATEGORY,x)
-#define MDEBUG(x) MCDEBUG(LOKI_DEFAULT_LOG_CATEGORY,x)
-#define MTRACE(x) MCTRACE(LOKI_DEFAULT_LOG_CATEGORY,x)
-#define MLOG(level,x) MCLOG(level,LOKI_DEFAULT_LOG_CATEGORY,x)
+#define MFATAL(x) MCFATAL(OXEN_DEFAULT_LOG_CATEGORY,x)
+#define MERROR(x) MCERROR(OXEN_DEFAULT_LOG_CATEGORY,x)
+#define MWARNING(x) MCWARNING(OXEN_DEFAULT_LOG_CATEGORY,x)
+#define MINFO(x) MCINFO(OXEN_DEFAULT_LOG_CATEGORY,x)
+#define MDEBUG(x) MCDEBUG(OXEN_DEFAULT_LOG_CATEGORY,x)
+#define MTRACE(x) MCTRACE(OXEN_DEFAULT_LOG_CATEGORY,x)
+#define MLOG(level,x) MCLOG(level,OXEN_DEFAULT_LOG_CATEGORY,x)
 
 #define MGINFO(x) MCINFO("global",x)
 #define MGINFO_RED(x) MCLOG_RED(el::Level::Info, "global",x)
@@ -97,7 +97,7 @@
       el::base::Writer(level, __FILE__, __LINE__, ELPP_FUNC, type).construct(cat) << x; \
     } \
   } while(0)
-#define MIDEBUG(init, x) IFLOG(el::Level::Debug, LOKI_DEFAULT_LOG_CATEGORY, el::base::DispatchAction::NormalLog, init, x)
+#define MIDEBUG(init, x) IFLOG(el::Level::Debug, OXEN_DEFAULT_LOG_CATEGORY, el::base::DispatchAction::NormalLog, init, x)
 
 
 #define LOG_ERROR(x) MERROR(x)

--- a/contrib/epee/include/epee/net/abstract_tcp_server2.h
+++ b/contrib/epee/include/epee/net/abstract_tcp_server2.h
@@ -50,8 +50,8 @@
 #include "connection_basic.hpp"
 #include "network_throttle-detail.hpp"
 
-#undef LOKI_DEFAULT_LOG_CATEGORY
-#define LOKI_DEFAULT_LOG_CATEGORY "net"
+#undef OXEN_DEFAULT_LOG_CATEGORY
+#define OXEN_DEFAULT_LOG_CATEGORY "net"
 
 #define ABSTRACT_SERVER_SEND_QUE_MAX_COUNT 1000
 

--- a/contrib/epee/include/epee/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/epee/net/abstract_tcp_server2.inl
@@ -51,8 +51,8 @@
 #include <functional>
 #include <random>
 
-#undef LOKI_DEFAULT_LOG_CATEGORY
-#define LOKI_DEFAULT_LOG_CATEGORY "net"
+#undef OXEN_DEFAULT_LOG_CATEGORY
+#define OXEN_DEFAULT_LOG_CATEGORY "net"
 
 #define AGGRESSIVE_TIMEOUT_THRESHOLD 120 // sockets
 #define NEW_CONNECTION_TIMEOUT_LOCAL 1200000 // 2 minutes

--- a/contrib/epee/include/epee/net/buffer.h
+++ b/contrib/epee/include/epee/net/buffer.h
@@ -32,8 +32,8 @@
 #include "../misc_log_ex.h"
 #include "../span.h"
 
-#undef LOKI_DEFAULT_LOG_CATEGORY
-#define LOKI_DEFAULT_LOG_CATEGORY "net.buffer"
+#undef OXEN_DEFAULT_LOG_CATEGORY
+#define OXEN_DEFAULT_LOG_CATEGORY "net.buffer"
 
 //#define NET_BUFFER_LOG(x) MDEBUG(x)
 #define NET_BUFFER_LOG(x) ((void)0)

--- a/contrib/epee/include/epee/net/levin_protocol_handler.h
+++ b/contrib/epee/include/epee/net/levin_protocol_handler.h
@@ -33,8 +33,8 @@
 #include "levin_base.h"
 #include "../int-util.h"
 
-#undef LOKI_DEFAULT_LOG_CATEGORY
-#define LOKI_DEFAULT_LOG_CATEGORY "net"
+#undef OXEN_DEFAULT_LOG_CATEGORY
+#define OXEN_DEFAULT_LOG_CATEGORY "net"
 
 namespace epee
 {

--- a/contrib/epee/include/epee/net/levin_protocol_handler_async.h
+++ b/contrib/epee/include/epee/net/levin_protocol_handler_async.h
@@ -42,8 +42,8 @@
 #include <random>
 #include <chrono>
 
-#undef LOKI_DEFAULT_LOG_CATEGORY
-#define LOKI_DEFAULT_LOG_CATEGORY "net"
+#undef OXEN_DEFAULT_LOG_CATEGORY
+#define OXEN_DEFAULT_LOG_CATEGORY "net"
 
 #ifndef MIN_BYTES_WANTED
 #define MIN_BYTES_WANTED	512

--- a/contrib/epee/include/epee/net/net_utils_base.h
+++ b/contrib/epee/include/epee/net/net_utils_base.h
@@ -40,8 +40,8 @@
 #include "../serialization/keyvalue_serialization.h"
 #include "../int-util.h"
 
-#undef LOKI_DEFAULT_LOG_CATEGORY
-#define LOKI_DEFAULT_LOG_CATEGORY "net"
+#undef OXEN_DEFAULT_LOG_CATEGORY
+#define OXEN_DEFAULT_LOG_CATEGORY "net"
 
 #ifndef MAKE_IP
 #define MAKE_IP( a1, a2, a3, a4 )	(a1|(a2<<8)|(a3<<16)|(((uint32_t)a4)<<24))

--- a/contrib/epee/include/epee/serialization/keyvalue_serialization.h
+++ b/contrib/epee/include/epee/serialization/keyvalue_serialization.h
@@ -30,8 +30,8 @@
 #include "keyvalue_serialization_overloads.h"
 #include "../storages/portable_storage.h"
 
-#undef LOKI_DEFAULT_LOG_CATEGORY
-#define LOKI_DEFAULT_LOG_CATEGORY "serialization"
+#undef OXEN_DEFAULT_LOG_CATEGORY
+#define OXEN_DEFAULT_LOG_CATEGORY "serialization"
 
 namespace epee
 {

--- a/contrib/epee/include/epee/serialization/keyvalue_serialization_overloads.h
+++ b/contrib/epee/include/epee/serialization/keyvalue_serialization_overloads.h
@@ -37,8 +37,8 @@
 #include "../span.h"
 #include "../storages/portable_storage_base.h"
 
-#undef LOKI_DEFAULT_LOG_CATEGORY
-#define LOKI_DEFAULT_LOG_CATEGORY "serialization"
+#undef OXEN_DEFAULT_LOG_CATEGORY
+#define OXEN_DEFAULT_LOG_CATEGORY "serialization"
 
 namespace epee
 {

--- a/contrib/epee/include/epee/storages/levin_abstract_invoke2.h
+++ b/contrib/epee/include/epee/storages/levin_abstract_invoke2.h
@@ -30,8 +30,8 @@
 #include "../span.h"
 #include "../net/levin_base.h"
 
-#undef LOKI_DEFAULT_LOG_CATEGORY
-#define LOKI_DEFAULT_LOG_CATEGORY "net"
+#undef OXEN_DEFAULT_LOG_CATEGORY
+#define OXEN_DEFAULT_LOG_CATEGORY "net"
 
 namespace epee
 {

--- a/contrib/epee/include/epee/storages/parserse_base_utils.h
+++ b/contrib/epee/include/epee/storages/parserse_base_utils.h
@@ -33,8 +33,8 @@
 #include <string_view>
 #include "../misc_log_ex.h"
 
-#undef MONERO_DEFAULT_LOG_CATEGORY
-#define MONERO_DEFAULT_LOG_CATEGORY "serialization"
+#undef OXEN_DEFAULT_LOG_CATEGORY
+#define OXEN_DEFAULT_LOG_CATEGORY "serialization"
 
 namespace epee 
 {

--- a/contrib/epee/src/buffer.cpp
+++ b/contrib/epee/src/buffer.cpp
@@ -32,8 +32,8 @@
 #include <cstdint>
 #include <vector>
 
-#undef LOKI_DEFAULT_LOG_CATEGORY
-#define LOKI_DEFAULT_LOG_CATEGORY "net.buffer"
+#undef OXEN_DEFAULT_LOG_CATEGORY
+#define OXEN_DEFAULT_LOG_CATEGORY "net.buffer"
 
 namespace epee
 {

--- a/contrib/epee/src/connection_basic.cpp
+++ b/contrib/epee/src/connection_basic.cpp
@@ -53,8 +53,8 @@
 #define GET_IO_SERVICE(s) ((s).get_io_service())
 #endif
 
-#undef LOKI_DEFAULT_LOG_CATEGORY
-#define LOKI_DEFAULT_LOG_CATEGORY "net.conn"
+#undef OXEN_DEFAULT_LOG_CATEGORY
+#define OXEN_DEFAULT_LOG_CATEGORY "net.conn"
 
 // ################################################################################################
 // local (TU local) headers

--- a/contrib/epee/src/mlocker.cpp
+++ b/contrib/epee/src/mlocker.cpp
@@ -45,8 +45,8 @@
 #include <mutex>
 #include <utility>
 
-#undef LOKI_DEFAULT_LOG_CATEGORY
-#define LOKI_DEFAULT_LOG_CATEGORY "mlocker"
+#undef OXEN_DEFAULT_LOG_CATEGORY
+#define OXEN_DEFAULT_LOG_CATEGORY "mlocker"
 
 // did an mlock operation previously fail? we only
 // want to log an error once and be done with it

--- a/contrib/epee/src/mlog.cpp
+++ b/contrib/epee/src/mlog.cpp
@@ -50,12 +50,12 @@ namespace fs { using namespace std::filesystem; }
 namespace fs = ghc::filesystem;
 #endif
 
-#undef LOKI_DEFAULT_LOG_CATEGORY
-#define LOKI_DEFAULT_LOG_CATEGORY "logging"
+#undef OXEN_DEFAULT_LOG_CATEGORY
+#define OXEN_DEFAULT_LOG_CATEGORY "logging"
 
 #define MLOG_BASE_FORMAT "%datetime{%Y-%M-%d %H:%m:%s.%g}\t%thread\t%level\t%logger\t%loc\t%msg"
 
-#define MLOG_LOG(x) CINFO(el::base::Writer,el::base::DispatchAction::FileOnlyLog,LOKI_DEFAULT_LOG_CATEGORY) << x
+#define MLOG_LOG(x) CINFO(el::base::Writer,el::base::DispatchAction::FileOnlyLog,OXEN_DEFAULT_LOG_CATEGORY) << x
 
 using namespace epee;
 
@@ -157,7 +157,7 @@ void mlog_configure(const std::string &filename_base, bool console, const std::s
   el::Configurations c;
   c.setGlobally(el::ConfigurationType::Filename, filename_base);
   c.setGlobally(el::ConfigurationType::ToFile, "true");
-  const char *log_format = getenv("LOKI_LOG_FORMAT");
+  const char *log_format = getenv("OXEN_LOG_FORMAT");
   if (!log_format)
     log_format = MLOG_BASE_FORMAT;
   c.setGlobally(el::ConfigurationType::Format, log_format);
@@ -206,7 +206,7 @@ void mlog_configure(const std::string &filename_base, bool console, const std::s
     }
   });
   mlog_set_common_prefix();
-  const char *loki_log = getenv("LOKI_LOGS");
+  const char *loki_log = getenv("OXEN_LOGS");
   if (!loki_log)
   {
     loki_log = get_default_categories(0);

--- a/contrib/epee/src/network_throttle-detail.cpp
+++ b/contrib/epee/src/network_throttle-detail.cpp
@@ -48,8 +48,8 @@
 // TODO:
 #include "epee/net/network_throttle-detail.hpp"
 
-#undef LOKI_DEFAULT_LOG_CATEGORY
-#define LOKI_DEFAULT_LOG_CATEGORY "net.throttle"
+#undef OXEN_DEFAULT_LOG_CATEGORY
+#define OXEN_DEFAULT_LOG_CATEGORY "net.throttle"
 
 // ################################################################################################
 // ################################################################################################

--- a/src/rpc/bootstrap_daemon.cpp
+++ b/src/rpc/bootstrap_daemon.cpp
@@ -7,8 +7,8 @@
 #include "cryptonote_core/cryptonote_core.h"
 #include "epee/misc_log_ex.h"
 
-#undef MONERO_DEFAULT_LOG_CATEGORY
-#define MONERO_DEFAULT_LOG_CATEGORY "daemon.rpc.bootstrap_daemon"
+#undef OXEN_DEFAULT_LOG_CATEGORY
+#define OXEN_DEFAULT_LOG_CATEGORY "daemon.rpc.bootstrap_daemon"
 
 namespace cryptonote
 {

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -61,8 +61,8 @@
 
 #include "blockchain_db/testdb.h"
 
-#undef LOKI_DEFAULT_LOG_CATEGORY
-#define LOKI_DEFAULT_LOG_CATEGORY "tests.core"
+#undef OXEN_DEFAULT_LOG_CATEGORY
+#define OXEN_DEFAULT_LOG_CATEGORY "tests.core"
 
 #define TESTS_DEFAULT_FEE ((uint64_t)200000000) // 2 * pow(10, 8)
 #define TEST_DEFAULT_DIFFICULTY 1

--- a/tests/unit_tests/service_nodes_swarm.cpp
+++ b/tests/unit_tests/service_nodes_swarm.cpp
@@ -36,8 +36,8 @@
 #include <iterator>
 #include <random>
 
-#undef LOKI_DEFAULT_LOG_CATEGORY
-#define LOKI_DEFAULT_LOG_CATEGORY "sn_unit_tests"
+#undef OXEN_DEFAULT_LOG_CATEGORY
+#define OXEN_DEFAULT_LOG_CATEGORY "sn_unit_tests"
 
 using namespace service_nodes;
 


### PR DESCRIPTION
Fixes some leftover instances of LOKI_DEFAULT_LOG_CATEGORY, primarily inside epee, which were breaking some logging macros (since we're defining OXEN_... everywhere in the src/ code).