### PR TITLE
Disable MMS and light wallet support by default

### DIFF
--- a/src/simplewallet/simplewallet-mms.inl
+++ b/src/simplewallet/simplewallet-mms.inl
@@ -1,0 +1,1046 @@
+// (Included from simplewallet.cpp when compiling with MMS support)
+
+// MMS ---------------------------------------------------------------------------------------------------
+
+// Access to the message store, or more exactly to the list of the messages that can be changed
+// by the idle thread, is guarded by the same mutex-based mechanism as access to the wallet
+// as a whole and thus e.g. uses the "LOCK_IDLE_SCOPE" macro. This is a little over-cautious, but
+// simple and safe. Care has to be taken however where MMS methods call other simplewallet methods
+// that use "LOCK_IDLE_SCOPE" as this cannot be nested!
+
+// Methods for commands like "export_multisig_info" usually read data from file(s) or write data
+// to files. The MMS calls now those methods as well, to produce data for messages and to process data
+// from messages. As it would be quite inconvenient for the MMS to write data for such methods to files
+// first or get data out of result files after the call, those methods detect a call from the MMS and
+// expect data as arguments instead of files and give back data by calling 'process_wallet_created_data'.
+
+//----------------------------------------------------------------------------------------------------
+void simple_wallet::check_for_messages()
+{
+  try
+  {
+    std::vector<mms::message> new_messages;
+    bool new_message = get_message_store().check_for_messages(get_multisig_wallet_state(), new_messages);
+    if (new_message)
+    {
+      message_writer(epee::console_color_magenta, true) << tr("MMS received new message");
+      list_mms_messages(new_messages);
+      m_cmd_binder.print_prompt();
+    }
+  }
+  catch(...) {}
+}
+//----------------------------------------------------------------------------------------------------
+bool simple_wallet::check_mms()
+{
+    // Check for new MMS messages;
+    // For simplicity auto message check is ALSO controlled by "m_auto_refresh_enabled" and has no
+    // separate thread either; thread syncing is tricky enough with only this one idle thread here
+    if (m_auto_refresh_enabled && get_message_store().get_active())
+    {
+      check_for_messages();
+    }
+    return true;
+}
+
+bool simple_wallet::user_confirms(const std::string &question)
+{
+   std::string answer = input_line(question + tr(" (Y/Yes/N/No): "));
+   return !std::cin.eof() && command_line::is_yes(answer);
+}
+
+bool simple_wallet::get_number_from_arg(const std::string &arg, uint32_t &number, const uint32_t lower_bound, const uint32_t upper_bound)
+{
+  bool valid = false;
+  try
+  {
+    number = boost::lexical_cast<uint32_t>(arg);
+    valid = (number >= lower_bound) && (number <= upper_bound);
+  }
+  catch(const boost::bad_lexical_cast &)
+  {
+  }
+  return valid;
+}
+
+bool simple_wallet::choose_mms_processing(const std::vector<mms::processing_data> &data_list, uint32_t &choice)
+{
+  size_t choices = data_list.size();
+  if (choices == 1)
+  {
+    choice = 0;
+    return true;
+  }
+  mms::message_store& ms = m_wallet->get_message_store();
+  message_writer() << tr("Choose processing:");
+  std::string text;
+  for (size_t i = 0; i < choices; ++i)
+  {
+    const mms::processing_data &data = data_list[i];
+    text = std::to_string(i+1) + ": ";
+    switch (data.processing)
+    {
+    case mms::message_processing::sign_tx:
+      text += tr("Sign tx");
+      break;
+    case mms::message_processing::send_tx:
+    {
+      mms::message m;
+      ms.get_message_by_id(data.message_ids[0], m);
+      if (m.type == mms::message_type::fully_signed_tx)
+      {
+        text += tr("Send the tx for submission to ");
+      }
+      else
+      {
+        text += tr("Send the tx for signing to ");
+      }
+      mms::authorized_signer signer = ms.get_signer(data.receiving_signer_index);
+      text += ms.signer_to_string(signer, 50);
+      break;
+    }
+    case mms::message_processing::submit_tx:
+      text += tr("Submit tx");
+      break;
+    default:
+      text += tr("unknown");
+      break;
+    }
+    message_writer() << text;
+  }
+
+  std::string line = input_line(tr("Choice: "));
+  if (std::cin.eof() || line.empty())
+  {
+    return false;
+  }
+  bool choice_ok = get_number_from_arg(line, choice, 1, choices);
+  if (choice_ok)
+  {
+    choice--;
+  }
+  else
+  {
+    fail_msg_writer() << tr("Wrong choice");
+  }
+  return choice_ok;
+}
+
+void simple_wallet::list_mms_messages(const std::vector<mms::message> &messages)
+{
+  message_writer() << boost::format("%4s %-4s %-30s %-21s %7s %3s %-15s %-40s") % tr("Id") % tr("I/O") % tr("Authorized Signer")
+          % tr("Message Type") % tr("Height") % tr("R") % tr("Message State") % tr("Since");
+  mms::message_store& ms = m_wallet->get_message_store();
+  uint64_t now = (uint64_t)time(NULL);
+  for (size_t i = 0; i < messages.size(); ++i)
+  {
+    const mms::message &m = messages[i];
+    const mms::authorized_signer &signer = ms.get_signer(m.signer_index);
+    bool highlight = (m.state == mms::message_state::ready_to_send) || (m.state == mms::message_state::waiting);
+    message_writer(m.direction == mms::message_direction::out ? epee::console_color_green : epee::console_color_magenta, highlight) <<
+            boost::format("%4s %-4s %-30s %-21s %7s %3s %-15s %-40s") %
+            m.id %
+            ms.message_direction_to_string(m.direction) %
+            ms.signer_to_string(signer, 30) %
+            ms.message_type_to_string(m.type) %
+            m.wallet_height %
+            m.round %
+            ms.message_state_to_string(m.state) %
+            (tools::get_human_readable_timestamp(m.modified) + ", " + tools::get_human_readable_timespan(std::chrono::seconds(now - m.modified)) + tr(" ago"));
+  }
+}
+
+void simple_wallet::list_signers(const std::vector<mms::authorized_signer> &signers)
+{
+  message_writer() << boost::format("%2s %-20s %-s") % tr("#") % tr("Label") % tr("Transport Address");
+  message_writer() << boost::format("%2s %-20s %-s") % "" % tr("Auto-Config Token") % tr("Oxen Address");
+  for (size_t i = 0; i < signers.size(); ++i)
+  {
+    const mms::authorized_signer &signer = signers[i];
+    std::string label = signer.label.empty() ? tr("<not set>") : signer.label;
+    std::string monero_address;
+    if (signer.monero_address_known)
+    {
+      monero_address = get_account_address_as_str(m_wallet->nettype(), false, signer.monero_address);
+    }
+    else
+    {
+      monero_address = tr("<not set>");
+    }
+    std::string transport_address = signer.transport_address.empty() ? tr("<not set>") : signer.transport_address;
+    message_writer() << boost::format("%2s %-20s %-s") % (i + 1) % label % transport_address;
+    message_writer() << boost::format("%2s %-20s %-s") % "" % signer.auto_config_token % monero_address;
+    message_writer() << "";
+  }
+}
+
+void simple_wallet::add_signer_config_messages()
+{
+  mms::message_store& ms = m_wallet->get_message_store();
+  std::string signer_config;
+  ms.get_signer_config(signer_config);
+
+  const std::vector<mms::authorized_signer> signers = ms.get_all_signers();
+  mms::multisig_wallet_state state = get_multisig_wallet_state();
+  uint32_t num_authorized_signers = ms.get_num_authorized_signers();
+  for (uint32_t i = 1 /* without me */; i < num_authorized_signers; ++i)
+  {
+    ms.add_message(state, i, mms::message_type::signer_config, mms::message_direction::out, signer_config);
+  }
+}
+
+void simple_wallet::show_message(const mms::message &m)
+{
+  mms::message_store& ms = m_wallet->get_message_store();
+  const mms::authorized_signer &signer = ms.get_signer(m.signer_index);
+  bool display_content;
+  std::string sanitized_text;
+  switch (m.type)
+  {
+  case mms::message_type::key_set:
+  case mms::message_type::additional_key_set:
+  case mms::message_type::note:
+    display_content = true;
+    ms.get_sanitized_message_text(m, sanitized_text);
+    break;
+  default:
+    display_content = false;
+  }
+  uint64_t now = (uint64_t)time(NULL);
+  message_writer() << "";
+  message_writer() << tr("Message ") << m.id;
+  message_writer() << tr("In/out: ") << ms.message_direction_to_string(m.direction);
+  message_writer() << tr("Type: ") << ms.message_type_to_string(m.type);
+  message_writer() << tr("State: ") << boost::format(tr("%s since %s, %s ago")) %
+          ms.message_state_to_string(m.state) % tools::get_human_readable_timestamp(m.modified) % tools::get_human_readable_timespan(std::chrono::seconds(now - m.modified));
+  if (m.sent == 0)
+  {
+    message_writer() << tr("Sent: Never");
+  }
+  else
+  {
+    message_writer() << boost::format(tr("Sent: %s, %s ago")) %
+            tools::get_human_readable_timestamp(m.sent) % tools::get_human_readable_timespan(std::chrono::seconds(now - m.sent));
+  }
+  message_writer() << tr("Authorized signer: ") << ms.signer_to_string(signer, 100);
+  message_writer() << tr("Content size: ") << m.content.length() << tr(" bytes");
+  message_writer() << tr("Content: ") << (display_content ? sanitized_text : tr("(binary data)"));
+
+  if (m.type == mms::message_type::note)
+  {
+    // Showing a note and read its text is "processing" it: Set the state accordingly
+    // which will also delete it from Bitmessage as a side effect
+    // (Without this little "twist" it would never change the state, and never get deleted)
+    ms.set_message_processed_or_sent(m.id);
+  }
+}
+
+void simple_wallet::ask_send_all_ready_messages()
+{
+  mms::message_store& ms = m_wallet->get_message_store();
+  std::vector<mms::message> ready_messages;
+  const std::vector<mms::message> &messages = ms.get_all_messages();
+  for (size_t i = 0; i < messages.size(); ++i)
+  {
+    const mms::message &m = messages[i];
+    if (m.state == mms::message_state::ready_to_send)
+    {
+      ready_messages.push_back(m);
+    }
+  }
+  if (ready_messages.size() != 0)
+  {
+    list_mms_messages(ready_messages);
+    bool send = ms.get_auto_send();
+    if (!send)
+    {
+      send = user_confirms(tr("Send these messages now?"));
+    }
+    if (send)
+    {
+      mms::multisig_wallet_state state = get_multisig_wallet_state();
+      for (size_t i = 0; i < ready_messages.size(); ++i)
+      {
+        ms.send_message(state, ready_messages[i].id);
+        ms.set_message_processed_or_sent(ready_messages[i].id);
+      }
+      success_msg_writer() << tr("Queued for sending.");
+    }
+  }
+}
+
+bool simple_wallet::get_message_from_arg(const std::string &arg, mms::message &m)
+{
+  mms::message_store& ms = m_wallet->get_message_store();
+  bool valid_id = false;
+  uint32_t id;
+  try
+  {
+    id = (uint32_t)boost::lexical_cast<uint32_t>(arg);
+    valid_id = ms.get_message_by_id(id, m);
+  }
+  catch (const boost::bad_lexical_cast &)
+  {
+  }
+  if (!valid_id)
+  {
+    fail_msg_writer() << tr("Invalid message id");
+  }
+  return valid_id;
+}
+
+void simple_wallet::mms_init(const std::vector<std::string> &args)
+{
+  if (args.size() != 3)
+  {
+    fail_msg_writer() << tr("usage: mms init <required_signers>/<authorized_signers> <own_label> <own_transport_address>");
+    return;
+  }
+  mms::message_store& ms = m_wallet->get_message_store();
+  if (ms.get_active())
+  {
+    if (!user_confirms(tr("The MMS is already initialized. Re-initialize by deleting all signer info and messages?")))
+    {
+      return;
+    }
+  }
+  uint32_t num_required_signers;
+  uint32_t num_authorized_signers;
+  const std::string &mn = args[0];
+  std::vector<std::string> numbers;
+  boost::split(numbers, mn, boost::is_any_of("/"));
+  bool mn_ok = (numbers.size() == 2)
+               && get_number_from_arg(numbers[1], num_authorized_signers, 2, 100)
+               && get_number_from_arg(numbers[0], num_required_signers, 2, num_authorized_signers);
+  if (!mn_ok)
+  {
+    fail_msg_writer() << tr("Error in the number of required signers and/or authorized signers");
+    return;
+  }
+  LOCK_IDLE_SCOPE();
+  ms.init(get_multisig_wallet_state(), args[1], args[2], num_authorized_signers, num_required_signers);
+}
+
+void simple_wallet::mms_info(const std::vector<std::string> &args)
+{
+  mms::message_store& ms = m_wallet->get_message_store();
+  if (ms.get_active())
+  {
+    message_writer() << boost::format("The MMS is active for %s/%s multisig.")
+            % ms.get_num_required_signers() % ms.get_num_authorized_signers();
+  }
+  else
+  {
+    message_writer() << tr("The MMS is not active.");
+  }
+}
+
+void simple_wallet::mms_signer(const std::vector<std::string> &args)
+{
+  mms::message_store& ms = m_wallet->get_message_store();
+  const std::vector<mms::authorized_signer> &signers = ms.get_all_signers();
+  if (args.size() == 0)
+  {
+    // Without further parameters list all defined signers
+    list_signers(signers);
+    return;
+  }
+
+  uint32_t index;
+  bool index_valid = get_number_from_arg(args[0], index, 1, ms.get_num_authorized_signers());
+  if (index_valid)
+  {
+    index--;
+  }
+  else
+  {
+    fail_msg_writer() << tr("Invalid signer number ") + args[0];
+    return;
+  }
+  if ((args.size() < 2) || (args.size() > 4))
+  {
+    fail_msg_writer() << tr("mms signer [<number> <label> [<transport_address> [<oxen_address>]]]");
+    return;
+  }
+
+  std::optional<std::string> label = args[1];
+  std::optional<std::string> transport_address;
+  if (args.size() >= 3)
+  {
+    transport_address = args[2];
+  }
+  std::optional<cryptonote::account_public_address> monero_address;
+  LOCK_IDLE_SCOPE();
+  mms::multisig_wallet_state state = get_multisig_wallet_state();
+  if (args.size() == 4)
+  {
+    cryptonote::address_parse_info info;
+    bool ok = cryptonote::get_account_address_from_str_or_url(info, m_wallet->nettype(), args[3], oa_prompter);
+    if (!ok)
+    {
+      fail_msg_writer() << tr("Invalid Oxen address");
+      return;
+    }
+    monero_address = info.address;
+    const std::vector<mms::message> &messages = ms.get_all_messages();
+    if ((messages.size() > 0) || state.multisig)
+    {
+      fail_msg_writer() << tr("Wallet state does not allow changing Oxen addresses anymore");
+      return;
+    }
+  }
+  ms.set_signer(state, index, label, transport_address, monero_address);
+}
+
+void simple_wallet::mms_list(const std::vector<std::string> &args)
+{
+  mms::message_store& ms = m_wallet->get_message_store();
+  if (args.size() != 0)
+  {
+    fail_msg_writer() << tr("Usage: mms list");
+    return;
+  }
+  LOCK_IDLE_SCOPE();
+  const std::vector<mms::message> &messages = ms.get_all_messages();
+  list_mms_messages(messages);
+}
+
+void simple_wallet::mms_next(const std::vector<std::string> &args)
+{
+  mms::message_store& ms = m_wallet->get_message_store();
+  if ((args.size() > 1) || ((args.size() == 1) && (args[0] != "sync")))
+  {
+    fail_msg_writer() << tr("Usage: mms next [sync]");
+    return;
+  }
+  bool avail = false;
+  std::vector<mms::processing_data> data_list;
+  bool force_sync = false;
+  uint32_t choice = 0;
+  {
+    LOCK_IDLE_SCOPE();
+    if ((args.size() == 1) && (args[0] == "sync"))
+    {
+      // Force the MMS to process any waiting sync info although on its own it would just ignore
+      // those messages because no need to process them can be seen
+      force_sync = true;
+    }
+    std::string wait_reason;
+    {
+      avail = ms.get_processable_messages(get_multisig_wallet_state(), force_sync, data_list, wait_reason);
+    }
+    if (avail)
+    {
+      avail = choose_mms_processing(data_list, choice);
+    }
+    else if (!wait_reason.empty())
+    {
+      message_writer() << tr("No next step: ") << wait_reason;
+    }
+  }
+  if (avail)
+  {
+    mms::processing_data data = data_list[choice];
+    bool command_successful = false;
+    switch(data.processing)
+    {
+    case mms::message_processing::prepare_multisig:
+      message_writer() << tr("prepare_multisig");
+      command_successful = prepare_multisig_main(std::vector<std::string>(), true);
+      break;
+
+    case mms::message_processing::make_multisig:
+    {
+      message_writer() << tr("make_multisig");
+      size_t number_of_key_sets = data.message_ids.size();
+      std::vector<std::string> sig_args(number_of_key_sets + 1);
+      sig_args[0] = std::to_string(ms.get_num_required_signers());
+      for (size_t i = 0; i < number_of_key_sets; ++i)
+      {
+        mms::message m = ms.get_message_by_id(data.message_ids[i]);
+        sig_args[i+1] = m.content;
+      }
+      command_successful = make_multisig_main(sig_args, true);
+      break;
+    }
+
+    case mms::message_processing::exchange_multisig_keys:
+    {
+      message_writer() << tr("exchange_multisig_keys");
+      size_t number_of_key_sets = data.message_ids.size();
+      // Other than "make_multisig" only the key sets as parameters, no num_required_signers
+      std::vector<std::string> sig_args(number_of_key_sets);
+      for (size_t i = 0; i < number_of_key_sets; ++i)
+      {
+        mms::message m = ms.get_message_by_id(data.message_ids[i]);
+        sig_args[i] = m.content;
+      }
+      command_successful = exchange_multisig_keys_main(sig_args, true);
+      break;
+    }
+
+    case mms::message_processing::create_sync_data:
+    {
+      message_writer() << tr("export_multisig_info");
+      std::vector<std::string> export_args;
+      export_args.push_back("MMS");  // dummy filename
+      command_successful = export_multisig_main(export_args, true);
+      break;
+    }
+
+    case mms::message_processing::process_sync_data:
+    {
+      message_writer() << tr("import_multisig_info");
+      std::vector<std::string> import_args;
+      for (size_t i = 0; i < data.message_ids.size(); ++i)
+      {
+        mms::message m = ms.get_message_by_id(data.message_ids[i]);
+        import_args.push_back(m.content);
+      }
+      command_successful = import_multisig_main(import_args, true);
+      break;
+    }
+
+    case mms::message_processing::sign_tx:
+    {
+      message_writer() << tr("sign_multisig");
+      std::vector<std::string> sign_args;
+      mms::message m = ms.get_message_by_id(data.message_ids[0]);
+      sign_args.push_back(m.content);
+      command_successful = sign_multisig_main(sign_args, true);
+      break;
+    }
+
+    case mms::message_processing::submit_tx:
+    {
+      message_writer() << tr("submit_multisig");
+      std::vector<std::string> submit_args;
+      mms::message m = ms.get_message_by_id(data.message_ids[0]);
+      submit_args.push_back(m.content);
+      command_successful = submit_multisig_main(submit_args, true);
+      break;
+    }
+
+    case mms::message_processing::send_tx:
+    {
+      message_writer() << tr("Send tx");
+      mms::message m = ms.get_message_by_id(data.message_ids[0]);
+      LOCK_IDLE_SCOPE();
+      ms.add_message(get_multisig_wallet_state(), data.receiving_signer_index, m.type, mms::message_direction::out,
+                     m.content);
+      command_successful = true;
+      break;
+    }
+
+    case mms::message_processing::process_signer_config:
+    {
+      message_writer() << tr("Process signer config");
+      LOCK_IDLE_SCOPE();
+      mms::message m = ms.get_message_by_id(data.message_ids[0]);
+      mms::authorized_signer me = ms.get_signer(0);
+      mms::multisig_wallet_state state = get_multisig_wallet_state();
+      if (!me.auto_config_running)
+      {
+        // If no auto-config is running, the config sent may be unsolicited or problematic
+        // so show what arrived and ask for confirmation before taking it in
+        std::vector<mms::authorized_signer> signers;
+        ms.unpack_signer_config(state, m.content, signers);
+        list_signers(signers);
+        if (!user_confirms(tr("Replace current signer config with the one displayed above?")))
+        {
+          break;
+        }
+      }
+      ms.process_signer_config(state, m.content);
+      ms.stop_auto_config();
+      list_signers(ms.get_all_signers());
+      command_successful = true;
+      break;
+    }
+
+    case mms::message_processing::process_auto_config_data:
+    {
+      message_writer() << tr("Process auto config data");
+      LOCK_IDLE_SCOPE();
+      for (size_t i = 0; i < data.message_ids.size(); ++i)
+      {
+        ms.process_auto_config_data_message(data.message_ids[i]);
+      }
+      ms.stop_auto_config();
+      list_signers(ms.get_all_signers());
+      add_signer_config_messages();
+      command_successful = true;
+      break;
+    }
+
+    default:
+      message_writer() << tr("Nothing ready to process");
+      break;
+    }
+
+    if (command_successful)
+    {
+      {
+        LOCK_IDLE_SCOPE();
+        ms.set_messages_processed(data);
+        ask_send_all_ready_messages();
+      }
+    }
+  }
+}
+
+void simple_wallet::mms_sync(const std::vector<std::string> &args)
+{
+  mms::message_store& ms = m_wallet->get_message_store();
+  if (args.size() != 0)
+  {
+    fail_msg_writer() << tr("Usage: mms sync");
+    return;
+  }
+  // Force the start of a new sync round, for exceptional cases where something went wrong
+  // Can e.g. solve the problem "This signature was made with stale data" after trying to
+  // create 2 transactions in a row somehow
+  // Code is identical to the code for 'message_processing::create_sync_data'
+  message_writer() << tr("export_multisig_info");
+  std::vector<std::string> export_args;
+  export_args.push_back("MMS");  // dummy filename
+  export_multisig_main(export_args, true);
+  ask_send_all_ready_messages();
+}
+
+void simple_wallet::mms_transfer(const std::vector<std::string> &args)
+{
+  // It's too complicated to check any arguments here, just let 'transfer_main' do the whole job
+  transfer_main(Transfer::Normal, args, true);
+}
+
+void simple_wallet::mms_delete(const std::vector<std::string> &args)
+{
+  if (args.size() != 1)
+  {
+    fail_msg_writer() << tr("Usage: mms delete (<message_id> | all)");
+    return;
+  }
+  LOCK_IDLE_SCOPE();
+  mms::message_store& ms = m_wallet->get_message_store();
+  if (args[0] == "all")
+  {
+    if (user_confirms(tr("Delete all messages?")))
+    {
+      ms.delete_all_messages();
+    }
+  }
+  else
+  {
+    mms::message m;
+    bool valid_id = get_message_from_arg(args[0], m);
+    if (valid_id)
+    {
+      // If only a single message and not all delete even if unsent / unprocessed
+      ms.delete_message(m.id);
+    }
+  }
+}
+
+void simple_wallet::mms_send(const std::vector<std::string> &args)
+{
+  if (args.size() == 0)
+  {
+    ask_send_all_ready_messages();
+    return;
+  }
+  else if (args.size() != 1)
+  {
+    fail_msg_writer() << tr("Usage: mms send [<message_id>]");
+    return;
+  }
+  LOCK_IDLE_SCOPE();
+  mms::message_store& ms = m_wallet->get_message_store();
+  mms::message m;
+  bool valid_id = get_message_from_arg(args[0], m);
+  if (valid_id)
+  {
+    ms.send_message(get_multisig_wallet_state(), m.id);
+  }
+}
+
+void simple_wallet::mms_receive(const std::vector<std::string> &args)
+{
+  if (args.size() != 0)
+  {
+    fail_msg_writer() << tr("Usage: mms receive");
+    return;
+  }
+  std::vector<mms::message> new_messages;
+  LOCK_IDLE_SCOPE();
+  mms::message_store& ms = m_wallet->get_message_store();
+  bool avail = ms.check_for_messages(get_multisig_wallet_state(), new_messages);
+  if (avail)
+  {
+    list_mms_messages(new_messages);
+  }
+}
+
+void simple_wallet::mms_export(const std::vector<std::string> &args)
+{
+  if (args.size() != 1)
+  {
+    fail_msg_writer() << tr("Usage: mms export <message_id>");
+    return;
+  }
+  LOCK_IDLE_SCOPE();
+  mms::message_store& ms = m_wallet->get_message_store();
+  mms::message m;
+  bool valid_id = get_message_from_arg(args[0], m);
+  if (valid_id)
+  {
+    fs::path filename = fs::u8path("mms_message_content");
+    if (m_wallet->save_to_file(filename, m.content))
+    {
+      success_msg_writer() << tr("Message content saved to: ") << filename;
+    }
+    else
+    {
+      fail_msg_writer() << tr("Failed to to save message content");
+    }
+  }
+}
+
+void simple_wallet::mms_note(const std::vector<std::string> &args)
+{
+  mms::message_store& ms = m_wallet->get_message_store();
+  if (args.size() == 0)
+  {
+    LOCK_IDLE_SCOPE();
+    const std::vector<mms::message> &messages = ms.get_all_messages();
+    for (size_t i = 0; i < messages.size(); ++i)
+    {
+      const mms::message &m = messages[i];
+      if ((m.type == mms::message_type::note) && (m.state == mms::message_state::waiting))
+      {
+        show_message(m);
+      }
+    }
+    return;
+  }
+  if (args.size() < 2)
+  {
+    fail_msg_writer() << tr("Usage: mms note [<label> <text>]");
+    return;
+  }
+  uint32_t signer_index;
+  bool found = ms.get_signer_index_by_label(args[0], signer_index);
+  if (!found)
+  {
+    fail_msg_writer() << tr("No signer found with label ") << args[0];
+    return;
+  }
+  std::string note = "";
+  for (size_t n = 1; n < args.size(); ++n)
+  {
+    if (n > 1)
+    {
+      note += " ";
+    }
+    note += args[n];
+  }
+  LOCK_IDLE_SCOPE();
+  ms.add_message(get_multisig_wallet_state(), signer_index, mms::message_type::note,
+                 mms::message_direction::out, note);
+  ask_send_all_ready_messages();
+}
+
+void simple_wallet::mms_show(const std::vector<std::string> &args)
+{
+  if (args.size() != 1)
+  {
+    fail_msg_writer() << tr("Usage: mms show <message_id>");
+    return;
+  }
+  LOCK_IDLE_SCOPE();
+  mms::message_store& ms = m_wallet->get_message_store();
+  mms::message m;
+  bool valid_id = get_message_from_arg(args[0], m);
+  if (valid_id)
+  {
+    show_message(m);
+  }
+}
+
+void simple_wallet::mms_set(const std::vector<std::string> &args)
+{
+  bool set = args.size() == 2;
+  bool query = args.size() == 1;
+  if (!set && !query)
+  {
+    fail_msg_writer() << tr("Usage: mms set <option_name> [<option_value>]");
+    return;
+  }
+  mms::message_store& ms = m_wallet->get_message_store();
+  LOCK_IDLE_SCOPE();
+  if (args[0] == "auto-send")
+  {
+    if (set)
+    {
+      bool result;
+      bool ok = parse_bool(args[1], result);
+      if (ok)
+      {
+        ms.set_auto_send(result);
+      }
+      else
+      {
+        fail_msg_writer() << tr("Wrong option value");
+      }
+    }
+    else
+    {
+      message_writer() << (ms.get_auto_send() ? tr("Auto-send is on") : tr("Auto-send is off"));
+    }
+  }
+  else
+  {
+    fail_msg_writer() << tr("Unknown option");
+  }
+}
+
+void simple_wallet::mms_help(const std::vector<std::string> &args)
+{
+  if (args.size() > 1)
+  {
+    fail_msg_writer() << tr("Usage: mms help [<subcommand>]");
+    return;
+  }
+  std::vector<std::string> help_args;
+  help_args.push_back("mms");
+  if (args.size() == 1)
+  {
+    help_args.push_back(args[0]);
+  }
+  help(help_args);
+}
+
+void simple_wallet::mms_send_signer_config(const std::vector<std::string> &args)
+{
+  if (args.size() != 0)
+  {
+    fail_msg_writer() << tr("Usage: mms send_signer_config");
+    return;
+  }
+  mms::message_store& ms = m_wallet->get_message_store();
+  if (!ms.signer_config_complete())
+  {
+    fail_msg_writer() << tr("Signer config not yet complete");
+    return;
+  }
+  LOCK_IDLE_SCOPE();
+  add_signer_config_messages();
+  ask_send_all_ready_messages();
+}
+
+void simple_wallet::mms_start_auto_config(const std::vector<std::string> &args)
+{
+  mms::message_store& ms = m_wallet->get_message_store();
+  uint32_t other_signers = ms.get_num_authorized_signers() - 1;
+  size_t args_size = args.size();
+  if ((args_size != 0) && (args_size != other_signers))
+  {
+    fail_msg_writer() << tr("Usage: mms start_auto_config [<label> <label> ...]");
+    return;
+  }
+  if ((args_size == 0) && !ms.signer_labels_complete())
+  {
+    fail_msg_writer() << tr("There are signers without a label set. Complete labels before auto-config or specify them as parameters here.");
+    return;
+  }
+  mms::authorized_signer me = ms.get_signer(0);
+  if (me.auto_config_running)
+  {
+    if (!user_confirms(tr("Auto-config is already running. Cancel and restart?")))
+    {
+      return;
+    }
+  }
+  LOCK_IDLE_SCOPE();
+  mms::multisig_wallet_state state = get_multisig_wallet_state();
+  if (args_size != 0)
+  {
+    // Set (or overwrite) all the labels except "me" from the arguments
+    for (uint32_t i = 1; i < (other_signers + 1); ++i)
+    {
+      ms.set_signer(state, i, args[i - 1], std::nullopt, std::nullopt);
+    }
+  }
+  ms.start_auto_config(state);
+  // List the signers to show the generated auto-config tokens
+  list_signers(ms.get_all_signers());
+}
+
+void simple_wallet::mms_stop_auto_config(const std::vector<std::string> &args)
+{
+  if (args.size() != 0)
+  {
+    fail_msg_writer() << tr("Usage: mms stop_auto_config");
+    return;
+  }
+  if (!user_confirms(tr("Delete any auto-config tokens and stop auto-config?")))
+  {
+    return;
+  }
+  mms::message_store& ms = m_wallet->get_message_store();
+  LOCK_IDLE_SCOPE();
+  ms.stop_auto_config();
+}
+
+void simple_wallet::mms_auto_config(const std::vector<std::string> &args)
+{
+  if (args.size() != 1)
+  {
+    fail_msg_writer() << tr("Usage: mms auto_config <auto_config_token>");
+    return;
+  }
+  mms::message_store& ms = m_wallet->get_message_store();
+  std::string adjusted_token;
+  if (!ms.check_auto_config_token(args[0], adjusted_token))
+  {
+    fail_msg_writer() << tr("Invalid auto-config token");
+    return;
+  }
+  mms::authorized_signer me = ms.get_signer(0);
+  if (me.auto_config_running)
+  {
+    if (!user_confirms(tr("Auto-config already running. Cancel and restart?")))
+    {
+      return;
+    }
+  }
+  LOCK_IDLE_SCOPE();
+  ms.add_auto_config_data_message(get_multisig_wallet_state(), adjusted_token);
+  ask_send_all_ready_messages();
+}
+
+bool simple_wallet::mms(const std::vector<std::string> &args)
+{
+  try
+  {
+    m_wallet->get_multisig_wallet_state();
+  }
+  catch(const std::exception &e)
+  {
+    fail_msg_writer() << tr("MMS not available in this wallet");
+    return true;
+  }
+
+  try
+  {
+    mms::message_store& ms = m_wallet->get_message_store();
+    if (args.size() == 0)
+    {
+      mms_info(args);
+      return true;
+    }
+
+    const std::string &sub_command = args[0];
+    std::vector<std::string> mms_args = args;
+    mms_args.erase(mms_args.begin());
+
+    if (sub_command == "init")
+    {
+      mms_init(mms_args);
+      return true;
+    }
+    if (!ms.get_active())
+    {
+      fail_msg_writer() << tr("The MMS is not active. Activate using the \"mms init\" command");
+      return true;
+    }
+    else if (sub_command == "info")
+    {
+      mms_info(mms_args);
+    }
+    else if (sub_command == "signer")
+    {
+      mms_signer(mms_args);
+    }
+    else if (sub_command == "list")
+    {
+      mms_list(mms_args);
+    }
+    else if (sub_command == "next")
+    {
+      mms_next(mms_args);
+    }
+    else if (sub_command == "sync")
+    {
+      mms_sync(mms_args);
+    }
+    else if (sub_command == "transfer")
+    {
+      mms_transfer(mms_args);
+    }
+    else if (sub_command == "delete")
+    {
+      mms_delete(mms_args);
+    }
+    else if (sub_command == "send")
+    {
+      mms_send(mms_args);
+    }
+    else if (sub_command == "receive")
+    {
+      mms_receive(mms_args);
+    }
+    else if (sub_command == "export")
+    {
+      mms_export(mms_args);
+    }
+    else if (sub_command == "note")
+    {
+      mms_note(mms_args);
+    }
+    else if (sub_command == "show")
+    {
+      mms_show(mms_args);
+    }
+    else if (sub_command == "set")
+    {
+      mms_set(mms_args);
+    }
+    else if (sub_command == "help")
+    {
+      mms_help(mms_args);
+    }
+    else if (sub_command == "send_signer_config")
+    {
+      mms_send_signer_config(mms_args);
+    }
+    else if (sub_command == "start_auto_config")
+    {
+      mms_start_auto_config(mms_args);
+    }
+    else if (sub_command == "stop_auto_config")
+    {
+      mms_stop_auto_config(mms_args);
+    }
+    else if (sub_command == "auto_config")
+    {
+      mms_auto_config(mms_args);
+    }
+    else
+    {
+      fail_msg_writer() << tr("Invalid MMS subcommand");
+    }
+  }
+  catch (const tools::error::no_connection_to_daemon &e)
+  {
+    fail_msg_writer() << tr("Error in MMS command: ") << e.what() << " " << e.request();
+  }
+  catch (const std::exception &e)
+  {
+    fail_msg_writer() << tr("Error in MMS command: ") << e.what();
+    PRINT_USAGE(USAGE_MMS);
+    return true;
+  }
+  return true;
+}
+// End MMS ------------------------------------------------------------------------------------------------

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -81,7 +81,9 @@
 #include <stdexcept>
 #include "epee/int-util.h"
 #include "epee/readline_suspend.h"
+#ifdef WALLET_ENABLE_MMS
 #include "wallet/message_store.h"
+#endif
 #include "wallet/wallet_rpc_server_commands_defs.h"
 #include "epee/string_coding.h"
 
@@ -212,6 +214,7 @@ namespace
   const char* USAGE_SIGN_MULTISIG("sign_multisig <filename>");
   const char* USAGE_SUBMIT_MULTISIG("submit_multisig <filename>");
   const char* USAGE_EXPORT_RAW_MULTISIG_TX("export_raw_multisig_tx <filename>");
+#ifdef WALLET_ENABLE_MMS
   const char* USAGE_MMS("mms [<subcommand> [<subcommand_parameters>]]");
   const char* USAGE_MMS_INIT("mms init <required_signers>/<authorized_signers> <own_label> <own_transport_address>");
   const char* USAGE_MMS_INFO("mms info");
@@ -231,6 +234,7 @@ namespace
   const char* USAGE_MMS_START_AUTO_CONFIG("mms start_auto_config [<label> <label> ...]");
   const char* USAGE_MMS_STOP_AUTO_CONFIG("mms stop_auto_config");
   const char* USAGE_MMS_AUTO_CONFIG("mms auto_config <auto_config_token>");
+#endif
   const char* USAGE_PRINT_RING("print_ring <key_image> | <txid>");
   const char* USAGE_SET_RING("set_ring <filename> | ( <key_image> absolute|relative <index> [<index>...] )");
   const char* USAGE_UNSET_RING("unset_ring <txid> | ( <key_image> [<key_image>...] )");
@@ -928,11 +932,11 @@ bool simple_wallet::print_fee_info(const std::vector<std::string> &args/* = std:
 
 bool simple_wallet::prepare_multisig(const std::vector<std::string> &args)
 {
-  prepare_multisig_main(args, false);
+  prepare_multisig_main(args ENABLE_IF_MMS(, false));
   return true;
 }
 
-bool simple_wallet::prepare_multisig_main(const std::vector<std::string> &args, bool called_by_mms)
+bool simple_wallet::prepare_multisig_main(const std::vector<std::string> &args ENABLE_IF_MMS(, bool called_by_mms))
 {
   if (m_wallet->key_on_device())
   {
@@ -963,21 +967,23 @@ bool simple_wallet::prepare_multisig_main(const std::vector<std::string> &args, 
   success_msg_writer() << tr("Send this multisig info to all other participants, then use make_multisig <threshold> <info1> [<info2>...] with others' multisig info");
   success_msg_writer() << tr("This includes the PRIVATE view key, so needs to be disclosed only to that multisig wallet's participants ");
 
+#ifdef WALLET_ENABLE_MMS
   if (called_by_mms)
   {
     get_message_store().process_wallet_created_data(get_multisig_wallet_state(), mms::message_type::key_set, multisig_info);
   }
+#endif
 
   return true;
 }
 
 bool simple_wallet::make_multisig(const std::vector<std::string> &args)
 {
-  make_multisig_main(args, false);
+  make_multisig_main(args ENABLE_IF_MMS(, false));
   return true;
 }
 
-bool simple_wallet::make_multisig_main(const std::vector<std::string> &args, bool called_by_mms)
+bool simple_wallet::make_multisig_main(const std::vector<std::string> &args ENABLE_IF_MMS(, bool called_by_mms))
 {
   if (m_wallet->key_on_device())
   {
@@ -1034,10 +1040,12 @@ bool simple_wallet::make_multisig_main(const std::vector<std::string> &args, boo
       success_msg_writer() << tr("Another step is needed");
       success_msg_writer() << multisig_extra_info;
       success_msg_writer() << tr("Send this multisig info to all other participants, then use exchange_multisig_keys <info1> [<info2>...] with others' multisig info");
+#ifdef WALLET_ENABLE_MMS
       if (called_by_mms)
       {
         get_message_store().process_wallet_created_data(get_multisig_wallet_state(), mms::message_type::additional_key_set, multisig_extra_info);
       }
+#endif
       return true;
     }
   }
@@ -1113,11 +1121,11 @@ bool simple_wallet::finalize_multisig(const std::vector<std::string> &args)
 
 bool simple_wallet::exchange_multisig_keys(const std::vector<std::string> &args)
 {
-  exchange_multisig_keys_main(args, false);
+  exchange_multisig_keys_main(args ENABLE_IF_MMS(, false));
   return true;
 }
 
-bool simple_wallet::exchange_multisig_keys_main(const std::vector<std::string> &args, bool called_by_mms) {
+bool simple_wallet::exchange_multisig_keys_main(const std::vector<std::string> &args ENABLE_IF_MMS(, bool called_by_mms)) {
     bool ready;
     if (m_wallet->key_on_device())
     {
@@ -1156,10 +1164,12 @@ bool simple_wallet::exchange_multisig_keys_main(const std::vector<std::string> &
         message_writer() << tr("Another step is needed");
         message_writer() << multisig_extra_info;
         message_writer() << tr("Send this multisig info to all other participants, then use exchange_multisig_keys <info1> [<info2>...] with others' multisig info");
+#ifdef WALLET_ENABLE_MMS
         if (called_by_mms)
         {
           get_message_store().process_wallet_created_data(get_multisig_wallet_state(), mms::message_type::additional_key_set, multisig_extra_info);
         }
+#endif
         return true;
       } else {
         uint32_t threshold, total;
@@ -1179,11 +1189,11 @@ bool simple_wallet::exchange_multisig_keys_main(const std::vector<std::string> &
 
 bool simple_wallet::export_multisig(const std::vector<std::string> &args)
 {
-  export_multisig_main(args, false);
+  export_multisig_main(args ENABLE_IF_MMS(, false));
   return true;
 }
 
-bool simple_wallet::export_multisig_main(const std::vector<std::string> &args, bool called_by_mms)
+bool simple_wallet::export_multisig_main(const std::vector<std::string> &args ENABLE_IF_MMS(, bool called_by_mms))
 {
   bool ready;
   if (m_wallet->key_on_device())
@@ -1208,7 +1218,11 @@ bool simple_wallet::export_multisig_main(const std::vector<std::string> &args, b
   }
 
   const fs::path filename = fs::u8path(args[0]);
-  if (!called_by_mms && m_wallet->confirm_export_overwrite() && !check_file_overwrite(filename))
+  if (
+#ifdef WALLET_ENABLE_MMS
+          !called_by_mms &&
+#endif
+          m_wallet->confirm_export_overwrite() && !check_file_overwrite(filename))
     return true;
 
   SCOPED_WALLET_UNLOCK_ON_BAD_PASSWORD(return false;);
@@ -1217,11 +1231,13 @@ bool simple_wallet::export_multisig_main(const std::vector<std::string> &args, b
   {
     cryptonote::blobdata ciphertext = m_wallet->export_multisig();
 
+#ifdef WALLET_ENABLE_MMS
     if (called_by_mms)
     {
       get_message_store().process_wallet_created_data(get_multisig_wallet_state(), mms::message_type::multisig_sync_data, ciphertext);
     }
     else
+#endif
     {
       bool r = m_wallet->save_to_file(filename, ciphertext);
       if (!r)
@@ -1244,11 +1260,11 @@ bool simple_wallet::export_multisig_main(const std::vector<std::string> &args, b
 
 bool simple_wallet::import_multisig(const std::vector<std::string> &args)
 {
-  import_multisig_main(args, false);
+  import_multisig_main(args ENABLE_IF_MMS(, false));
   return true;
 }
 
-bool simple_wallet::import_multisig_main(const std::vector<std::string> &args, bool called_by_mms)
+bool simple_wallet::import_multisig_main(const std::vector<std::string> &args ENABLE_IF_MMS(, bool called_by_mms))
 {
   bool ready;
   uint32_t threshold, total;
@@ -1276,11 +1292,13 @@ bool simple_wallet::import_multisig_main(const std::vector<std::string> &args, b
   std::vector<cryptonote::blobdata> info;
   for (size_t n = 0; n < args.size(); ++n)
   {
+#ifdef WALLET_ENABLE_MMS
     if (called_by_mms)
     {
       info.push_back(args[n]);
     }
     else
+#endif
     {
       const fs::path filename = fs::u8path(args[n]);
       std::string data;
@@ -1339,11 +1357,11 @@ bool simple_wallet::accept_loaded_tx(const tools::wallet2::multisig_tx_set &txs)
 
 bool simple_wallet::sign_multisig(const std::vector<std::string> &args)
 {
-  sign_multisig_main(args, false);
+  sign_multisig_main(args ENABLE_IF_MMS(, false));
   return true;
 }
 
-bool simple_wallet::sign_multisig_main(const std::vector<std::string> &args, bool called_by_mms)
+bool simple_wallet::sign_multisig_main(const std::vector<std::string> &args ENABLE_IF_MMS(, bool called_by_mms))
 {
   bool ready;
   if (m_wallet->key_on_device())
@@ -1374,6 +1392,7 @@ bool simple_wallet::sign_multisig_main(const std::vector<std::string> &args, boo
   uint32_t signers = 0;
   try
   {
+#ifdef WALLET_ENABLE_MMS
     if (called_by_mms)
     {
       tools::wallet2::multisig_tx_set exported_txs;
@@ -1408,6 +1427,7 @@ bool simple_wallet::sign_multisig_main(const std::vector<std::string> &args, boo
       }
     }
     else
+#endif
     {
       bool r = m_wallet->sign_multisig_tx_from_file(filename, txids, [&](const tools::wallet2::multisig_tx_set &tx){ signers = tx.m_signers.size(); return accept_loaded_tx(tx); });
       if (!r)
@@ -1454,11 +1474,11 @@ bool simple_wallet::sign_multisig_main(const std::vector<std::string> &args, boo
 
 bool simple_wallet::submit_multisig(const std::vector<std::string> &args)
 {
-  submit_multisig_main(args, false);
+  submit_multisig_main(args ENABLE_IF_MMS(, false));
   return true;
 }
 
-bool simple_wallet::submit_multisig_main(const std::vector<std::string> &args, bool called_by_mms)
+bool simple_wallet::submit_multisig_main(const std::vector<std::string> &args ENABLE_IF_MMS(, bool called_by_mms))
 {
   bool ready;
   uint32_t threshold;
@@ -1492,6 +1512,7 @@ bool simple_wallet::submit_multisig_main(const std::vector<std::string> &args, b
   try
   {
     tools::wallet2::multisig_tx_set txs;
+#ifdef WALLET_ENABLE_MMS
     if (called_by_mms)
     {
       bool r = m_wallet->load_multisig_tx(args[0], txs, [&](const tools::wallet2::multisig_tx_set &tx){ return accept_loaded_tx(tx); });
@@ -1502,6 +1523,7 @@ bool simple_wallet::submit_multisig_main(const std::vector<std::string> &args, b
       }
     }
     else
+#endif
     {
       bool r = m_wallet->load_multisig_tx_from_file(filename, txs, [&](const tools::wallet2::multisig_tx_set &tx){ return accept_loaded_tx(tx); });
       if (!r)
@@ -2595,12 +2617,14 @@ bool simple_wallet::help(const std::vector<std::string> &args/* = std::vector<st
   {
     success_msg_writer() << get_commands_str();
   }
+#ifdef WALLET_ENABLE_MMS
   else if ((args.size() == 2) && (args.front() == "mms"))
   {
     // Little hack to be able to do "help mms <subcommand>"
     std::vector<std::string> mms_args(1, args.front() + " " + args.back());
     success_msg_writer() << get_command_usage(mms_args);
   }
+#endif
   else
   {
     success_msg_writer() << get_command_usage(args);
@@ -2981,6 +3005,7 @@ Pending or Failed: "failed"|"pending",  "out", Lock, Checkpointed, Time, Amount*
                            [this](const auto& x) { return export_raw_multisig(x); },
                            tr(USAGE_EXPORT_RAW_MULTISIG_TX),
                            tr("Export a signed multisig transaction to a file"));
+#ifdef WALLET_ENABLE_MMS
   m_cmd_binder.set_handler("mms",
                            [this](const auto& x) { return mms(x); },
                            tr(USAGE_MMS),
@@ -3064,6 +3089,7 @@ Pending or Failed: "failed"|"pending",  "out", Lock, Checkpointed, Time, Amount*
                            [this](const auto& x) { return mms(x); },
                            tr(USAGE_MMS_AUTO_CONFIG),
                            tr("Start auto-config by using the token received from the auto-config manager"));
+#endif
   m_cmd_binder.set_handler("print_ring",
                            [this](const auto& x) { return print_ring(x); },
                            tr(USAGE_PRINT_RING),
@@ -5697,7 +5723,7 @@ std::array<std::string, sizeof...(Prefixes)> eat_named_arguments(std::vector<std
   return { eat_named_argument(args, prefixes)... };
 }
 //----------------------------------------------------------------------------------------------------
-bool simple_wallet::confirm_and_send_tx(std::vector<cryptonote::address_parse_info> const &dests, std::vector<tools::wallet2::pending_tx> &ptx_vector, bool blink, uint64_t lock_time_in_blocks, uint64_t unlock_block, bool called_by_mms)
+bool simple_wallet::confirm_and_send_tx(std::vector<cryptonote::address_parse_info> const &dests, std::vector<tools::wallet2::pending_tx> &ptx_vector, bool blink, uint64_t lock_time_in_blocks, uint64_t unlock_block ENABLE_IF_MMS(, bool called_by_mms))
 {
   if (ptx_vector.empty())
     return false;
@@ -5792,26 +5818,31 @@ bool simple_wallet::confirm_and_send_tx(std::vector<cryptonote::address_parse_in
   }
 
   // actually commit the transactions
-  if (m_wallet->multisig() && called_by_mms)
+  if (m_wallet->multisig())
   {
-    std::string ciphertext = m_wallet->save_multisig_tx(ptx_vector);
-    if (!ciphertext.empty())
+#ifdef WALLET_ENABLE_MMS
+    if (called_by_mms)
     {
-      get_message_store().process_wallet_created_data(get_multisig_wallet_state(), mms::message_type::partially_signed_tx, ciphertext);
-      success_msg_writer(true) << tr("Unsigned transaction(s) successfully written to MMS");
-    }
-  }
-  else if (m_wallet->multisig())
-  {
-    bool r = m_wallet->save_multisig_tx(ptx_vector, "multisig_oxen_tx");
-    if (!r)
-    {
-      fail_msg_writer() << tr("Failed to write transaction(s) to file");
-      return false;
+      std::string ciphertext = m_wallet->save_multisig_tx(ptx_vector);
+      if (!ciphertext.empty())
+      {
+        get_message_store().process_wallet_created_data(get_multisig_wallet_state(), mms::message_type::partially_signed_tx, ciphertext);
+        success_msg_writer(true) << tr("Unsigned transaction(s) successfully written to MMS");
+      }
     }
     else
+#endif
     {
-      success_msg_writer(true) << tr("Unsigned transaction(s) successfully written to file: ") << "multisig_oxen_tx";
+      bool r = m_wallet->save_multisig_tx(ptx_vector, "multisig_oxen_tx");
+      if (!r)
+      {
+        fail_msg_writer() << tr("Failed to write transaction(s) to file");
+        return false;
+      }
+      else
+      {
+        success_msg_writer(true) << tr("Unsigned transaction(s) successfully written to file: ") << "multisig_oxen_tx";
+      }
     }
   }
   else if (m_wallet->get_account().get_device().has_tx_cold_sign())
@@ -5860,7 +5891,7 @@ bool simple_wallet::confirm_and_send_tx(std::vector<cryptonote::address_parse_in
 }
 
 //  "transfer [index=<N1>[,<N2>,...]] [<priority>] <address> <amount> [<payment_id>]"
-bool simple_wallet::transfer_main(Transfer transfer_type, const std::vector<std::string> &args_, bool called_by_mms)
+bool simple_wallet::transfer_main(Transfer transfer_type, const std::vector<std::string> &args_ ENABLE_IF_MMS(, bool called_by_mms))
 {
   if (!try_connect_to_daemon())
     return false;
@@ -5922,7 +5953,6 @@ bool simple_wallet::transfer_main(Transfer transfer_type, const std::vector<std:
   bool payment_id_seen = false;
   std::vector<cryptonote::address_parse_info> dsts_info;
   std::vector<cryptonote::tx_destination_entry> dsts;
-  size_t num_subaddresses = 0;
   for (size_t i = 0; i < local_args.size(); )
   {
     dsts_info.emplace_back();
@@ -5973,7 +6003,6 @@ bool simple_wallet::transfer_main(Transfer transfer_type, const std::vector<std:
     de.addr = info.address;
     de.is_subaddress = info.is_subaddress;
     de.is_integrated = info.has_payment_id;
-    num_subaddresses += info.is_subaddress;
 
     if (info.has_payment_id || !payment_id_uri.empty())
     {
@@ -6032,7 +6061,7 @@ bool simple_wallet::transfer_main(Transfer transfer_type, const std::vector<std:
     std::optional<uint8_t> hf_version = m_wallet->get_hard_fork_version();
     if (!hf_version)
     {
-      fail_msg_writer() << tools::ERR_MSG_NETWORK_VERSION_QUERY_FAILED;
+      fail_msg_writer() << tools::wallet2::ERR_MSG_NETWORK_VERSION_QUERY_FAILED;
       return false;
     }
 
@@ -6046,7 +6075,7 @@ bool simple_wallet::transfer_main(Transfer transfer_type, const std::vector<std:
       return false;
     }
 
-    if (!confirm_and_send_tx(dsts_info, ptx_vector, priority == tools::tx_priority_blink, locked_blocks, unlock_block, called_by_mms))
+    if (!confirm_and_send_tx(dsts_info, ptx_vector, priority == tools::tx_priority_blink, locked_blocks, unlock_block ENABLE_IF_MMS(, called_by_mms)))
       return false;
   }
   catch (const std::exception &e)
@@ -6067,12 +6096,12 @@ bool simple_wallet::transfer_main(Transfer transfer_type, const std::vector<std:
 bool simple_wallet::transfer(const std::vector<std::string> &args_)
 {
 
-  return transfer_main(Transfer::Normal, args_, false);
+  return transfer_main(Transfer::Normal, args_ ENABLE_IF_MMS(, false));
 }
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::locked_transfer(const std::vector<std::string> &args_)
 {
-  return transfer_main(Transfer::Locked, args_, false);
+  return transfer_main(Transfer::Locked, args_ ENABLE_IF_MMS(, false));
 }
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::locked_sweep_all(const std::vector<std::string> &args_)
@@ -6464,7 +6493,7 @@ static std::optional<ons::mapping_type> guess_ons_type(tools::wallet2& wallet, s
   auto hf_version = wallet.get_hard_fork_version();
   if (!hf_version)
   {
-    tools::fail_msg_writer() << tools::ERR_MSG_NETWORK_VERSION_QUERY_FAILED;
+    tools::fail_msg_writer() << tools::wallet2::ERR_MSG_NETWORK_VERSION_QUERY_FAILED;
     return std::nullopt;
   }
 
@@ -6820,7 +6849,7 @@ bool simple_wallet::ons_encrypt(std::vector<std::string> args)
   std::optional<uint8_t> hf_version = m_wallet->get_hard_fork_version();
   if (!hf_version)
   {
-    tools::fail_msg_writer() << tools::ERR_MSG_NETWORK_VERSION_QUERY_FAILED;
+    tools::fail_msg_writer() << tools::wallet2::ERR_MSG_NETWORK_VERSION_QUERY_FAILED;
     return false;
   }
 
@@ -6900,7 +6929,7 @@ bool simple_wallet::ons_lookup(std::vector<std::string> args)
     auto hf_version = m_wallet->get_hard_fork_version();
     if (!hf_version)
     {
-      fail_msg_writer() << tools::ERR_MSG_NETWORK_VERSION_QUERY_FAILED;
+      fail_msg_writer() << tools::wallet2::ERR_MSG_NETWORK_VERSION_QUERY_FAILED;
       return false;
     }
 
@@ -6922,7 +6951,7 @@ bool simple_wallet::ons_lookup(std::vector<std::string> args)
     auto hf_version = m_wallet->get_hard_fork_version();
     if (!hf_version)
     {
-      fail_msg_writer() << tools::ERR_MSG_NETWORK_VERSION_QUERY_FAILED;
+      fail_msg_writer() << tools::wallet2::ERR_MSG_NETWORK_VERSION_QUERY_FAILED;
       return false;
     }
     auto all_types = ons::all_mapping_types(*hf_version);
@@ -8837,22 +8866,6 @@ bool simple_wallet::rescan_blockchain(const std::vector<std::string> &args_)
   return refresh_main(start_height, reset_type, true);
 }
 //----------------------------------------------------------------------------------------------------
-void simple_wallet::check_for_messages()
-{
-  try
-  {
-    std::vector<mms::message> new_messages;
-    bool new_message = get_message_store().check_for_messages(get_multisig_wallet_state(), new_messages);
-    if (new_message)
-    {
-      message_writer(epee::console_color_magenta, true) << tr("MMS received new message");
-      list_mms_messages(new_messages);
-      m_cmd_binder.print_prompt();
-    }
-  }
-  catch(...) {}
-}
-//----------------------------------------------------------------------------------------------------
 void simple_wallet::wallet_idle_thread()
 {
   const auto start_time = std::chrono::steady_clock::now();
@@ -8879,7 +8892,9 @@ void simple_wallet::wallet_idle_thread()
       m_inactivity_checker.do_call([this] { check_inactivity(); });
 #endif
       m_refresh_checker.do_call([this] { check_refresh(false /*long_poll_trigger*/); });
+#ifdef WALLET_ENABLE_MMS
       m_mms_checker.do_call([this] { check_mms(); });
+#endif
 
       if (!m_idle_run.load(std::memory_order_relaxed))
         break;
@@ -8922,18 +8937,6 @@ bool simple_wallet::check_refresh(bool long_poll_trigger)
       }
       catch(...) {}
       m_auto_refresh_refreshing = false;
-    }
-    return true;
-}
-//----------------------------------------------------------------------------------------------------
-bool simple_wallet::check_mms()
-{
-    // Check for new MMS messages;
-    // For simplicity auto message check is ALSO controlled by "m_auto_refresh_enabled" and has no
-    // separate thread either; thread syncing is tricky enough with only this one idle thread here
-    if (m_auto_refresh_enabled && get_message_store().get_active())
-    {
-      check_for_messages();
     }
     return true;
 }
@@ -10331,1018 +10334,6 @@ int main(int argc, char* argv[])
   CATCH_ENTRY_L0("main", 1);
 }
 
-// MMS ---------------------------------------------------------------------------------------------------
-
-// Access to the message store, or more exactly to the list of the messages that can be changed
-// by the idle thread, is guarded by the same mutex-based mechanism as access to the wallet
-// as a whole and thus e.g. uses the "LOCK_IDLE_SCOPE" macro. This is a little over-cautious, but
-// simple and safe. Care has to be taken however where MMS methods call other simplewallet methods
-// that use "LOCK_IDLE_SCOPE" as this cannot be nested!
-
-// Methods for commands like "export_multisig_info" usually read data from file(s) or write data
-// to files. The MMS calls now those methods as well, to produce data for messages and to process data
-// from messages. As it would be quite inconvenient for the MMS to write data for such methods to files
-// first or get data out of result files after the call, those methods detect a call from the MMS and
-// expect data as arguments instead of files and give back data by calling 'process_wallet_created_data'.
-
-bool simple_wallet::user_confirms(const std::string &question)
-{
-   std::string answer = input_line(question + tr(" (Y/Yes/N/No): "));
-   return !std::cin.eof() && command_line::is_yes(answer);
-}
-
-bool simple_wallet::get_number_from_arg(const std::string &arg, uint32_t &number, const uint32_t lower_bound, const uint32_t upper_bound)
-{
-  bool valid = false;
-  try
-  {
-    number = boost::lexical_cast<uint32_t>(arg);
-    valid = (number >= lower_bound) && (number <= upper_bound);
-  }
-  catch(const boost::bad_lexical_cast &)
-  {
-  }
-  return valid;
-}
-
-bool simple_wallet::choose_mms_processing(const std::vector<mms::processing_data> &data_list, uint32_t &choice)
-{
-  size_t choices = data_list.size();
-  if (choices == 1)
-  {
-    choice = 0;
-    return true;
-  }
-  mms::message_store& ms = m_wallet->get_message_store();
-  message_writer() << tr("Choose processing:");
-  std::string text;
-  for (size_t i = 0; i < choices; ++i)
-  {
-    const mms::processing_data &data = data_list[i];
-    text = std::to_string(i+1) + ": ";
-    switch (data.processing)
-    {
-    case mms::message_processing::sign_tx:
-      text += tr("Sign tx");
-      break;
-    case mms::message_processing::send_tx:
-    {
-      mms::message m;
-      ms.get_message_by_id(data.message_ids[0], m);
-      if (m.type == mms::message_type::fully_signed_tx)
-      {
-        text += tr("Send the tx for submission to ");
-      }
-      else
-      {
-        text += tr("Send the tx for signing to ");
-      }
-      mms::authorized_signer signer = ms.get_signer(data.receiving_signer_index);
-      text += ms.signer_to_string(signer, 50);
-      break;
-    }
-    case mms::message_processing::submit_tx:
-      text += tr("Submit tx");
-      break;
-    default:
-      text += tr("unknown");
-      break;
-    }
-    message_writer() << text;
-  }
-
-  std::string line = input_line(tr("Choice: "));
-  if (std::cin.eof() || line.empty())
-  {
-    return false;
-  }
-  bool choice_ok = get_number_from_arg(line, choice, 1, choices);
-  if (choice_ok)
-  {
-    choice--;
-  }
-  else
-  {
-    fail_msg_writer() << tr("Wrong choice");
-  }
-  return choice_ok;
-}
-
-void simple_wallet::list_mms_messages(const std::vector<mms::message> &messages)
-{
-  message_writer() << boost::format("%4s %-4s %-30s %-21s %7s %3s %-15s %-40s") % tr("Id") % tr("I/O") % tr("Authorized Signer")
-          % tr("Message Type") % tr("Height") % tr("R") % tr("Message State") % tr("Since");
-  mms::message_store& ms = m_wallet->get_message_store();
-  uint64_t now = (uint64_t)time(NULL);
-  for (size_t i = 0; i < messages.size(); ++i)
-  {
-    const mms::message &m = messages[i];
-    const mms::authorized_signer &signer = ms.get_signer(m.signer_index);
-    bool highlight = (m.state == mms::message_state::ready_to_send) || (m.state == mms::message_state::waiting);
-    message_writer(m.direction == mms::message_direction::out ? epee::console_color_green : epee::console_color_magenta, highlight) <<
-            boost::format("%4s %-4s %-30s %-21s %7s %3s %-15s %-40s") %
-            m.id %
-            ms.message_direction_to_string(m.direction) %
-            ms.signer_to_string(signer, 30) %
-            ms.message_type_to_string(m.type) %
-            m.wallet_height %
-            m.round %
-            ms.message_state_to_string(m.state) %
-            (tools::get_human_readable_timestamp(m.modified) + ", " + tools::get_human_readable_timespan(std::chrono::seconds(now - m.modified)) + tr(" ago"));
-  }
-}
-
-void simple_wallet::list_signers(const std::vector<mms::authorized_signer> &signers)
-{
-  message_writer() << boost::format("%2s %-20s %-s") % tr("#") % tr("Label") % tr("Transport Address");
-  message_writer() << boost::format("%2s %-20s %-s") % "" % tr("Auto-Config Token") % tr("Oxen Address");
-  for (size_t i = 0; i < signers.size(); ++i)
-  {
-    const mms::authorized_signer &signer = signers[i];
-    std::string label = signer.label.empty() ? tr("<not set>") : signer.label;
-    std::string monero_address;
-    if (signer.monero_address_known)
-    {
-      monero_address = get_account_address_as_str(m_wallet->nettype(), false, signer.monero_address);
-    }
-    else
-    {
-      monero_address = tr("<not set>");
-    }
-    std::string transport_address = signer.transport_address.empty() ? tr("<not set>") : signer.transport_address;
-    message_writer() << boost::format("%2s %-20s %-s") % (i + 1) % label % transport_address;
-    message_writer() << boost::format("%2s %-20s %-s") % "" % signer.auto_config_token % monero_address;
-    message_writer() << "";
-  }
-}
-
-void simple_wallet::add_signer_config_messages()
-{
-  mms::message_store& ms = m_wallet->get_message_store();
-  std::string signer_config;
-  ms.get_signer_config(signer_config);
-
-  const std::vector<mms::authorized_signer> signers = ms.get_all_signers();
-  mms::multisig_wallet_state state = get_multisig_wallet_state();
-  uint32_t num_authorized_signers = ms.get_num_authorized_signers();
-  for (uint32_t i = 1 /* without me */; i < num_authorized_signers; ++i)
-  {
-    ms.add_message(state, i, mms::message_type::signer_config, mms::message_direction::out, signer_config);
-  }
-}
-
-void simple_wallet::show_message(const mms::message &m)
-{
-  mms::message_store& ms = m_wallet->get_message_store();
-  const mms::authorized_signer &signer = ms.get_signer(m.signer_index);
-  bool display_content;
-  std::string sanitized_text;
-  switch (m.type)
-  {
-  case mms::message_type::key_set:
-  case mms::message_type::additional_key_set:
-  case mms::message_type::note:
-    display_content = true;
-    ms.get_sanitized_message_text(m, sanitized_text);
-    break;
-  default:
-    display_content = false;
-  }
-  uint64_t now = (uint64_t)time(NULL);
-  message_writer() << "";
-  message_writer() << tr("Message ") << m.id;
-  message_writer() << tr("In/out: ") << ms.message_direction_to_string(m.direction);
-  message_writer() << tr("Type: ") << ms.message_type_to_string(m.type);
-  message_writer() << tr("State: ") << boost::format(tr("%s since %s, %s ago")) %
-          ms.message_state_to_string(m.state) % tools::get_human_readable_timestamp(m.modified) % tools::get_human_readable_timespan(std::chrono::seconds(now - m.modified));
-  if (m.sent == 0)
-  {
-    message_writer() << tr("Sent: Never");
-  }
-  else
-  {
-    message_writer() << boost::format(tr("Sent: %s, %s ago")) %
-            tools::get_human_readable_timestamp(m.sent) % tools::get_human_readable_timespan(std::chrono::seconds(now - m.sent));
-  }
-  message_writer() << tr("Authorized signer: ") << ms.signer_to_string(signer, 100);
-  message_writer() << tr("Content size: ") << m.content.length() << tr(" bytes");
-  message_writer() << tr("Content: ") << (display_content ? sanitized_text : tr("(binary data)"));
-
-  if (m.type == mms::message_type::note)
-  {
-    // Showing a note and read its text is "processing" it: Set the state accordingly
-    // which will also delete it from Bitmessage as a side effect
-    // (Without this little "twist" it would never change the state, and never get deleted)
-    ms.set_message_processed_or_sent(m.id);
-  }
-}
-
-void simple_wallet::ask_send_all_ready_messages()
-{
-  mms::message_store& ms = m_wallet->get_message_store();
-  std::vector<mms::message> ready_messages;
-  const std::vector<mms::message> &messages = ms.get_all_messages();
-  for (size_t i = 0; i < messages.size(); ++i)
-  {
-    const mms::message &m = messages[i];
-    if (m.state == mms::message_state::ready_to_send)
-    {
-      ready_messages.push_back(m);
-    }
-  }
-  if (ready_messages.size() != 0)
-  {
-    list_mms_messages(ready_messages);
-    bool send = ms.get_auto_send();
-    if (!send)
-    {
-      send = user_confirms(tr("Send these messages now?"));
-    }
-    if (send)
-    {
-      mms::multisig_wallet_state state = get_multisig_wallet_state();
-      for (size_t i = 0; i < ready_messages.size(); ++i)
-      {
-        ms.send_message(state, ready_messages[i].id);
-        ms.set_message_processed_or_sent(ready_messages[i].id);
-      }
-      success_msg_writer() << tr("Queued for sending.");
-    }
-  }
-}
-
-bool simple_wallet::get_message_from_arg(const std::string &arg, mms::message &m)
-{
-  mms::message_store& ms = m_wallet->get_message_store();
-  bool valid_id = false;
-  uint32_t id;
-  try
-  {
-    id = (uint32_t)boost::lexical_cast<uint32_t>(arg);
-    valid_id = ms.get_message_by_id(id, m);
-  }
-  catch (const boost::bad_lexical_cast &)
-  {
-  }
-  if (!valid_id)
-  {
-    fail_msg_writer() << tr("Invalid message id");
-  }
-  return valid_id;
-}
-
-void simple_wallet::mms_init(const std::vector<std::string> &args)
-{
-  if (args.size() != 3)
-  {
-    fail_msg_writer() << tr("usage: mms init <required_signers>/<authorized_signers> <own_label> <own_transport_address>");
-    return;
-  }
-  mms::message_store& ms = m_wallet->get_message_store();
-  if (ms.get_active())
-  {
-    if (!user_confirms(tr("The MMS is already initialized. Re-initialize by deleting all signer info and messages?")))
-    {
-      return;
-    }
-  }
-  uint32_t num_required_signers;
-  uint32_t num_authorized_signers;
-  const std::string &mn = args[0];
-  std::vector<std::string> numbers;
-  boost::split(numbers, mn, boost::is_any_of("/"));
-  bool mn_ok = (numbers.size() == 2)
-               && get_number_from_arg(numbers[1], num_authorized_signers, 2, 100)
-               && get_number_from_arg(numbers[0], num_required_signers, 2, num_authorized_signers);
-  if (!mn_ok)
-  {
-    fail_msg_writer() << tr("Error in the number of required signers and/or authorized signers");
-    return;
-  }
-  LOCK_IDLE_SCOPE();
-  ms.init(get_multisig_wallet_state(), args[1], args[2], num_authorized_signers, num_required_signers);
-}
-
-void simple_wallet::mms_info(const std::vector<std::string> &args)
-{
-  mms::message_store& ms = m_wallet->get_message_store();
-  if (ms.get_active())
-  {
-    message_writer() << boost::format("The MMS is active for %s/%s multisig.")
-            % ms.get_num_required_signers() % ms.get_num_authorized_signers();
-  }
-  else
-  {
-    message_writer() << tr("The MMS is not active.");
-  }
-}
-
-void simple_wallet::mms_signer(const std::vector<std::string> &args)
-{
-  mms::message_store& ms = m_wallet->get_message_store();
-  const std::vector<mms::authorized_signer> &signers = ms.get_all_signers();
-  if (args.size() == 0)
-  {
-    // Without further parameters list all defined signers
-    list_signers(signers);
-    return;
-  }
-
-  uint32_t index;
-  bool index_valid = get_number_from_arg(args[0], index, 1, ms.get_num_authorized_signers());
-  if (index_valid)
-  {
-    index--;
-  }
-  else
-  {
-    fail_msg_writer() << tr("Invalid signer number ") + args[0];
-    return;
-  }
-  if ((args.size() < 2) || (args.size() > 4))
-  {
-    fail_msg_writer() << tr("mms signer [<number> <label> [<transport_address> [<oxen_address>]]]");
-    return;
-  }
-
-  std::optional<std::string> label = args[1];
-  std::optional<std::string> transport_address;
-  if (args.size() >= 3)
-  {
-    transport_address = args[2];
-  }
-  std::optional<cryptonote::account_public_address> monero_address;
-  LOCK_IDLE_SCOPE();
-  mms::multisig_wallet_state state = get_multisig_wallet_state();
-  if (args.size() == 4)
-  {
-    cryptonote::address_parse_info info;
-    bool ok = cryptonote::get_account_address_from_str_or_url(info, m_wallet->nettype(), args[3], oa_prompter);
-    if (!ok)
-    {
-      fail_msg_writer() << tr("Invalid Oxen address");
-      return;
-    }
-    monero_address = info.address;
-    const std::vector<mms::message> &messages = ms.get_all_messages();
-    if ((messages.size() > 0) || state.multisig)
-    {
-      fail_msg_writer() << tr("Wallet state does not allow changing Oxen addresses anymore");
-      return;
-    }
-  }
-  ms.set_signer(state, index, label, transport_address, monero_address);
-}
-
-void simple_wallet::mms_list(const std::vector<std::string> &args)
-{
-  mms::message_store& ms = m_wallet->get_message_store();
-  if (args.size() != 0)
-  {
-    fail_msg_writer() << tr("Usage: mms list");
-    return;
-  }
-  LOCK_IDLE_SCOPE();
-  const std::vector<mms::message> &messages = ms.get_all_messages();
-  list_mms_messages(messages);
-}
-
-void simple_wallet::mms_next(const std::vector<std::string> &args)
-{
-  mms::message_store& ms = m_wallet->get_message_store();
-  if ((args.size() > 1) || ((args.size() == 1) && (args[0] != "sync")))
-  {
-    fail_msg_writer() << tr("Usage: mms next [sync]");
-    return;
-  }
-  bool avail = false;
-  std::vector<mms::processing_data> data_list;
-  bool force_sync = false;
-  uint32_t choice = 0;
-  {
-    LOCK_IDLE_SCOPE();
-    if ((args.size() == 1) && (args[0] == "sync"))
-    {
-      // Force the MMS to process any waiting sync info although on its own it would just ignore
-      // those messages because no need to process them can be seen
-      force_sync = true;
-    }
-    std::string wait_reason;
-    {
-      avail = ms.get_processable_messages(get_multisig_wallet_state(), force_sync, data_list, wait_reason);
-    }
-    if (avail)
-    {
-      avail = choose_mms_processing(data_list, choice);
-    }
-    else if (!wait_reason.empty())
-    {
-      message_writer() << tr("No next step: ") << wait_reason;
-    }
-  }
-  if (avail)
-  {
-    mms::processing_data data = data_list[choice];
-    bool command_successful = false;
-    switch(data.processing)
-    {
-    case mms::message_processing::prepare_multisig:
-      message_writer() << tr("prepare_multisig");
-      command_successful = prepare_multisig_main(std::vector<std::string>(), true);
-      break;
-
-    case mms::message_processing::make_multisig:
-    {
-      message_writer() << tr("make_multisig");
-      size_t number_of_key_sets = data.message_ids.size();
-      std::vector<std::string> sig_args(number_of_key_sets + 1);
-      sig_args[0] = std::to_string(ms.get_num_required_signers());
-      for (size_t i = 0; i < number_of_key_sets; ++i)
-      {
-        mms::message m = ms.get_message_by_id(data.message_ids[i]);
-        sig_args[i+1] = m.content;
-      }
-      command_successful = make_multisig_main(sig_args, true);
-      break;
-    }
-
-    case mms::message_processing::exchange_multisig_keys:
-    {
-      message_writer() << tr("exchange_multisig_keys");
-      size_t number_of_key_sets = data.message_ids.size();
-      // Other than "make_multisig" only the key sets as parameters, no num_required_signers
-      std::vector<std::string> sig_args(number_of_key_sets);
-      for (size_t i = 0; i < number_of_key_sets; ++i)
-      {
-        mms::message m = ms.get_message_by_id(data.message_ids[i]);
-        sig_args[i] = m.content;
-      }
-      command_successful = exchange_multisig_keys_main(sig_args, true);
-      break;
-    }
-
-    case mms::message_processing::create_sync_data:
-    {
-      message_writer() << tr("export_multisig_info");
-      std::vector<std::string> export_args;
-      export_args.push_back("MMS");  // dummy filename
-      command_successful = export_multisig_main(export_args, true);
-      break;
-    }
-
-    case mms::message_processing::process_sync_data:
-    {
-      message_writer() << tr("import_multisig_info");
-      std::vector<std::string> import_args;
-      for (size_t i = 0; i < data.message_ids.size(); ++i)
-      {
-        mms::message m = ms.get_message_by_id(data.message_ids[i]);
-        import_args.push_back(m.content);
-      }
-      command_successful = import_multisig_main(import_args, true);
-      break;
-    }
-
-    case mms::message_processing::sign_tx:
-    {
-      message_writer() << tr("sign_multisig");
-      std::vector<std::string> sign_args;
-      mms::message m = ms.get_message_by_id(data.message_ids[0]);
-      sign_args.push_back(m.content);
-      command_successful = sign_multisig_main(sign_args, true);
-      break;
-    }
-
-    case mms::message_processing::submit_tx:
-    {
-      message_writer() << tr("submit_multisig");
-      std::vector<std::string> submit_args;
-      mms::message m = ms.get_message_by_id(data.message_ids[0]);
-      submit_args.push_back(m.content);
-      command_successful = submit_multisig_main(submit_args, true);
-      break;
-    }
-
-    case mms::message_processing::send_tx:
-    {
-      message_writer() << tr("Send tx");
-      mms::message m = ms.get_message_by_id(data.message_ids[0]);
-      LOCK_IDLE_SCOPE();
-      ms.add_message(get_multisig_wallet_state(), data.receiving_signer_index, m.type, mms::message_direction::out,
-                     m.content);
-      command_successful = true;
-      break;
-    }
-
-    case mms::message_processing::process_signer_config:
-    {
-      message_writer() << tr("Process signer config");
-      LOCK_IDLE_SCOPE();
-      mms::message m = ms.get_message_by_id(data.message_ids[0]);
-      mms::authorized_signer me = ms.get_signer(0);
-      mms::multisig_wallet_state state = get_multisig_wallet_state();
-      if (!me.auto_config_running)
-      {
-        // If no auto-config is running, the config sent may be unsolicited or problematic
-        // so show what arrived and ask for confirmation before taking it in
-        std::vector<mms::authorized_signer> signers;
-        ms.unpack_signer_config(state, m.content, signers);
-        list_signers(signers);
-        if (!user_confirms(tr("Replace current signer config with the one displayed above?")))
-        {
-          break;
-        }
-      }
-      ms.process_signer_config(state, m.content);
-      ms.stop_auto_config();
-      list_signers(ms.get_all_signers());
-      command_successful = true;
-      break;
-    }
-
-    case mms::message_processing::process_auto_config_data:
-    {
-      message_writer() << tr("Process auto config data");
-      LOCK_IDLE_SCOPE();
-      for (size_t i = 0; i < data.message_ids.size(); ++i)
-      {
-        ms.process_auto_config_data_message(data.message_ids[i]);
-      }
-      ms.stop_auto_config();
-      list_signers(ms.get_all_signers());
-      add_signer_config_messages();
-      command_successful = true;
-      break;
-    }
-
-    default:
-      message_writer() << tr("Nothing ready to process");
-      break;
-    }
-
-    if (command_successful)
-    {
-      {
-        LOCK_IDLE_SCOPE();
-        ms.set_messages_processed(data);
-        ask_send_all_ready_messages();
-      }
-    }
-  }
-}
-
-void simple_wallet::mms_sync(const std::vector<std::string> &args)
-{
-  mms::message_store& ms = m_wallet->get_message_store();
-  if (args.size() != 0)
-  {
-    fail_msg_writer() << tr("Usage: mms sync");
-    return;
-  }
-  // Force the start of a new sync round, for exceptional cases where something went wrong
-  // Can e.g. solve the problem "This signature was made with stale data" after trying to
-  // create 2 transactions in a row somehow
-  // Code is identical to the code for 'message_processing::create_sync_data'
-  message_writer() << tr("export_multisig_info");
-  std::vector<std::string> export_args;
-  export_args.push_back("MMS");  // dummy filename
-  export_multisig_main(export_args, true);
-  ask_send_all_ready_messages();
-}
-
-void simple_wallet::mms_transfer(const std::vector<std::string> &args)
-{
-  // It's too complicated to check any arguments here, just let 'transfer_main' do the whole job
-  transfer_main(Transfer::Normal, args, true);
-}
-
-void simple_wallet::mms_delete(const std::vector<std::string> &args)
-{
-  if (args.size() != 1)
-  {
-    fail_msg_writer() << tr("Usage: mms delete (<message_id> | all)");
-    return;
-  }
-  LOCK_IDLE_SCOPE();
-  mms::message_store& ms = m_wallet->get_message_store();
-  if (args[0] == "all")
-  {
-    if (user_confirms(tr("Delete all messages?")))
-    {
-      ms.delete_all_messages();
-    }
-  }
-  else
-  {
-    mms::message m;
-    bool valid_id = get_message_from_arg(args[0], m);
-    if (valid_id)
-    {
-      // If only a single message and not all delete even if unsent / unprocessed
-      ms.delete_message(m.id);
-    }
-  }
-}
-
-void simple_wallet::mms_send(const std::vector<std::string> &args)
-{
-  if (args.size() == 0)
-  {
-    ask_send_all_ready_messages();
-    return;
-  }
-  else if (args.size() != 1)
-  {
-    fail_msg_writer() << tr("Usage: mms send [<message_id>]");
-    return;
-  }
-  LOCK_IDLE_SCOPE();
-  mms::message_store& ms = m_wallet->get_message_store();
-  mms::message m;
-  bool valid_id = get_message_from_arg(args[0], m);
-  if (valid_id)
-  {
-    ms.send_message(get_multisig_wallet_state(), m.id);
-  }
-}
-
-void simple_wallet::mms_receive(const std::vector<std::string> &args)
-{
-  if (args.size() != 0)
-  {
-    fail_msg_writer() << tr("Usage: mms receive");
-    return;
-  }
-  std::vector<mms::message> new_messages;
-  LOCK_IDLE_SCOPE();
-  mms::message_store& ms = m_wallet->get_message_store();
-  bool avail = ms.check_for_messages(get_multisig_wallet_state(), new_messages);
-  if (avail)
-  {
-    list_mms_messages(new_messages);
-  }
-}
-
-void simple_wallet::mms_export(const std::vector<std::string> &args)
-{
-  if (args.size() != 1)
-  {
-    fail_msg_writer() << tr("Usage: mms export <message_id>");
-    return;
-  }
-  LOCK_IDLE_SCOPE();
-  mms::message_store& ms = m_wallet->get_message_store();
-  mms::message m;
-  bool valid_id = get_message_from_arg(args[0], m);
-  if (valid_id)
-  {
-    fs::path filename = fs::u8path("mms_message_content");
-    if (m_wallet->save_to_file(filename, m.content))
-    {
-      success_msg_writer() << tr("Message content saved to: ") << filename;
-    }
-    else
-    {
-      fail_msg_writer() << tr("Failed to to save message content");
-    }
-  }
-}
-
-void simple_wallet::mms_note(const std::vector<std::string> &args)
-{
-  mms::message_store& ms = m_wallet->get_message_store();
-  if (args.size() == 0)
-  {
-    LOCK_IDLE_SCOPE();
-    const std::vector<mms::message> &messages = ms.get_all_messages();
-    for (size_t i = 0; i < messages.size(); ++i)
-    {
-      const mms::message &m = messages[i];
-      if ((m.type == mms::message_type::note) && (m.state == mms::message_state::waiting))
-      {
-        show_message(m);
-      }
-    }
-    return;
-  }
-  if (args.size() < 2)
-  {
-    fail_msg_writer() << tr("Usage: mms note [<label> <text>]");
-    return;
-  }
-  uint32_t signer_index;
-  bool found = ms.get_signer_index_by_label(args[0], signer_index);
-  if (!found)
-  {
-    fail_msg_writer() << tr("No signer found with label ") << args[0];
-    return;
-  }
-  std::string note = "";
-  for (size_t n = 1; n < args.size(); ++n)
-  {
-    if (n > 1)
-    {
-      note += " ";
-    }
-    note += args[n];
-  }
-  LOCK_IDLE_SCOPE();
-  ms.add_message(get_multisig_wallet_state(), signer_index, mms::message_type::note,
-                 mms::message_direction::out, note);
-  ask_send_all_ready_messages();
-}
-
-void simple_wallet::mms_show(const std::vector<std::string> &args)
-{
-  if (args.size() != 1)
-  {
-    fail_msg_writer() << tr("Usage: mms show <message_id>");
-    return;
-  }
-  LOCK_IDLE_SCOPE();
-  mms::message_store& ms = m_wallet->get_message_store();
-  mms::message m;
-  bool valid_id = get_message_from_arg(args[0], m);
-  if (valid_id)
-  {
-    show_message(m);
-  }
-}
-
-void simple_wallet::mms_set(const std::vector<std::string> &args)
-{
-  bool set = args.size() == 2;
-  bool query = args.size() == 1;
-  if (!set && !query)
-  {
-    fail_msg_writer() << tr("Usage: mms set <option_name> [<option_value>]");
-    return;
-  }
-  mms::message_store& ms = m_wallet->get_message_store();
-  LOCK_IDLE_SCOPE();
-  if (args[0] == "auto-send")
-  {
-    if (set)
-    {
-      bool result;
-      bool ok = parse_bool(args[1], result);
-      if (ok)
-      {
-        ms.set_auto_send(result);
-      }
-      else
-      {
-        fail_msg_writer() << tr("Wrong option value");
-      }
-    }
-    else
-    {
-      message_writer() << (ms.get_auto_send() ? tr("Auto-send is on") : tr("Auto-send is off"));
-    }
-  }
-  else
-  {
-    fail_msg_writer() << tr("Unknown option");
-  }
-}
-
-void simple_wallet::mms_help(const std::vector<std::string> &args)
-{
-  if (args.size() > 1)
-  {
-    fail_msg_writer() << tr("Usage: mms help [<subcommand>]");
-    return;
-  }
-  std::vector<std::string> help_args;
-  help_args.push_back("mms");
-  if (args.size() == 1)
-  {
-    help_args.push_back(args[0]);
-  }
-  help(help_args);
-}
-
-void simple_wallet::mms_send_signer_config(const std::vector<std::string> &args)
-{
-  if (args.size() != 0)
-  {
-    fail_msg_writer() << tr("Usage: mms send_signer_config");
-    return;
-  }
-  mms::message_store& ms = m_wallet->get_message_store();
-  if (!ms.signer_config_complete())
-  {
-    fail_msg_writer() << tr("Signer config not yet complete");
-    return;
-  }
-  LOCK_IDLE_SCOPE();
-  add_signer_config_messages();
-  ask_send_all_ready_messages();
-}
-
-void simple_wallet::mms_start_auto_config(const std::vector<std::string> &args)
-{
-  mms::message_store& ms = m_wallet->get_message_store();
-  uint32_t other_signers = ms.get_num_authorized_signers() - 1;
-  size_t args_size = args.size();
-  if ((args_size != 0) && (args_size != other_signers))
-  {
-    fail_msg_writer() << tr("Usage: mms start_auto_config [<label> <label> ...]");
-    return;
-  }
-  if ((args_size == 0) && !ms.signer_labels_complete())
-  {
-    fail_msg_writer() << tr("There are signers without a label set. Complete labels before auto-config or specify them as parameters here.");
-    return;
-  }
-  mms::authorized_signer me = ms.get_signer(0);
-  if (me.auto_config_running)
-  {
-    if (!user_confirms(tr("Auto-config is already running. Cancel and restart?")))
-    {
-      return;
-    }
-  }
-  LOCK_IDLE_SCOPE();
-  mms::multisig_wallet_state state = get_multisig_wallet_state();
-  if (args_size != 0)
-  {
-    // Set (or overwrite) all the labels except "me" from the arguments
-    for (uint32_t i = 1; i < (other_signers + 1); ++i)
-    {
-      ms.set_signer(state, i, args[i - 1], std::nullopt, std::nullopt);
-    }
-  }
-  ms.start_auto_config(state);
-  // List the signers to show the generated auto-config tokens
-  list_signers(ms.get_all_signers());
-}
-
-void simple_wallet::mms_stop_auto_config(const std::vector<std::string> &args)
-{
-  if (args.size() != 0)
-  {
-    fail_msg_writer() << tr("Usage: mms stop_auto_config");
-    return;
-  }
-  if (!user_confirms(tr("Delete any auto-config tokens and stop auto-config?")))
-  {
-    return;
-  }
-  mms::message_store& ms = m_wallet->get_message_store();
-  LOCK_IDLE_SCOPE();
-  ms.stop_auto_config();
-}
-
-void simple_wallet::mms_auto_config(const std::vector<std::string> &args)
-{
-  if (args.size() != 1)
-  {
-    fail_msg_writer() << tr("Usage: mms auto_config <auto_config_token>");
-    return;
-  }
-  mms::message_store& ms = m_wallet->get_message_store();
-  std::string adjusted_token;
-  if (!ms.check_auto_config_token(args[0], adjusted_token))
-  {
-    fail_msg_writer() << tr("Invalid auto-config token");
-    return;
-  }
-  mms::authorized_signer me = ms.get_signer(0);
-  if (me.auto_config_running)
-  {
-    if (!user_confirms(tr("Auto-config already running. Cancel and restart?")))
-    {
-      return;
-    }
-  }
-  LOCK_IDLE_SCOPE();
-  ms.add_auto_config_data_message(get_multisig_wallet_state(), adjusted_token);
-  ask_send_all_ready_messages();
-}
-
-bool simple_wallet::mms(const std::vector<std::string> &args)
-{
-  try
-  {
-    m_wallet->get_multisig_wallet_state();
-  }
-  catch(const std::exception &e)
-  {
-    fail_msg_writer() << tr("MMS not available in this wallet");
-    return true;
-  }
-
-  try
-  {
-    mms::message_store& ms = m_wallet->get_message_store();
-    if (args.size() == 0)
-    {
-      mms_info(args);
-      return true;
-    }
-
-    const std::string &sub_command = args[0];
-    std::vector<std::string> mms_args = args;
-    mms_args.erase(mms_args.begin());
-
-    if (sub_command == "init")
-    {
-      mms_init(mms_args);
-      return true;
-    }
-    if (!ms.get_active())
-    {
-      fail_msg_writer() << tr("The MMS is not active. Activate using the \"mms init\" command");
-      return true;
-    }
-    else if (sub_command == "info")
-    {
-      mms_info(mms_args);
-    }
-    else if (sub_command == "signer")
-    {
-      mms_signer(mms_args);
-    }
-    else if (sub_command == "list")
-    {
-      mms_list(mms_args);
-    }
-    else if (sub_command == "next")
-    {
-      mms_next(mms_args);
-    }
-    else if (sub_command == "sync")
-    {
-      mms_sync(mms_args);
-    }
-    else if (sub_command == "transfer")
-    {
-      mms_transfer(mms_args);
-    }
-    else if (sub_command == "delete")
-    {
-      mms_delete(mms_args);
-    }
-    else if (sub_command == "send")
-    {
-      mms_send(mms_args);
-    }
-    else if (sub_command == "receive")
-    {
-      mms_receive(mms_args);
-    }
-    else if (sub_command == "export")
-    {
-      mms_export(mms_args);
-    }
-    else if (sub_command == "note")
-    {
-      mms_note(mms_args);
-    }
-    else if (sub_command == "show")
-    {
-      mms_show(mms_args);
-    }
-    else if (sub_command == "set")
-    {
-      mms_set(mms_args);
-    }
-    else if (sub_command == "help")
-    {
-      mms_help(mms_args);
-    }
-    else if (sub_command == "send_signer_config")
-    {
-      mms_send_signer_config(mms_args);
-    }
-    else if (sub_command == "start_auto_config")
-    {
-      mms_start_auto_config(mms_args);
-    }
-    else if (sub_command == "stop_auto_config")
-    {
-      mms_stop_auto_config(mms_args);
-    }
-    else if (sub_command == "auto_config")
-    {
-      mms_auto_config(mms_args);
-    }
-    else
-    {
-      fail_msg_writer() << tr("Invalid MMS subcommand");
-    }
-  }
-  catch (const tools::error::no_connection_to_daemon &e)
-  {
-    fail_msg_writer() << tr("Error in MMS command: ") << e.what() << " " << e.request();
-  }
-  catch (const std::exception &e)
-  {
-    fail_msg_writer() << tr("Error in MMS command: ") << e.what();
-    PRINT_USAGE(USAGE_MMS);
-    return true;
-  }
-  return true;
-}
-// End MMS ------------------------------------------------------------------------------------------------
+#ifdef WALLET_ENABLE_MMS
+#include "simplewallet-mms.inl"
+#endif

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -169,8 +169,8 @@ namespace cryptonote
 
     // lock_time_in_blocks: Only required if making a locked transfer, only for displaying to the user, it should be the lock time specified by the sender
     // unlock_block:        Only required if lock_time_in_blocks is specified, only for displaying to the user, the height at which the transfer will unlock
-    bool confirm_and_send_tx(std::vector<cryptonote::address_parse_info> const &dests, std::vector<tools::wallet2::pending_tx> &ptx_vector, bool blink, uint64_t lock_time_in_blocks = 0, uint64_t unlock_block = 0, bool called_by_mms = false);
-    bool transfer_main(Transfer transfer_type, const std::vector<std::string> &args, bool called_by_mms);
+    bool confirm_and_send_tx(std::vector<cryptonote::address_parse_info> const &dests, std::vector<tools::wallet2::pending_tx> &ptx_vector, bool blink, uint64_t lock_time_in_blocks = 0, uint64_t unlock_block = 0 ENABLE_IF_MMS(, bool called_by_mms = false));
+    bool transfer_main(Transfer transfer_type, const std::vector<std::string> &args ENABLE_IF_MMS(, bool called_by_mms));
 
     bool transfer(const std::vector<std::string> &args);
     bool locked_transfer(const std::vector<std::string> &args);
@@ -251,23 +251,25 @@ namespace cryptonote
     bool payment_id(const std::vector<std::string> &args);
     bool print_fee_info(const std::vector<std::string> &args);
     bool prepare_multisig(const std::vector<std::string>& args);
-    bool prepare_multisig_main(const std::vector<std::string>& args, bool called_by_mms);
+    bool prepare_multisig_main(const std::vector<std::string>& args ENABLE_IF_MMS(, bool called_by_mms));
     bool make_multisig(const std::vector<std::string>& args);
-    bool make_multisig_main(const std::vector<std::string>& args, bool called_by_mms);
+    bool make_multisig_main(const std::vector<std::string>& args ENABLE_IF_MMS(, bool called_by_mms));
     bool finalize_multisig(const std::vector<std::string> &args);
     bool exchange_multisig_keys(const std::vector<std::string> &args);
-    bool exchange_multisig_keys_main(const std::vector<std::string> &args, bool called_by_mms);
+    bool exchange_multisig_keys_main(const std::vector<std::string> &args ENABLE_IF_MMS(, bool called_by_mms));
     bool export_multisig(const std::vector<std::string>& args);
-    bool export_multisig_main(const std::vector<std::string>& args, bool called_by_mms);
+    bool export_multisig_main(const std::vector<std::string>& args ENABLE_IF_MMS(, bool called_by_mms));
     bool import_multisig(const std::vector<std::string>& args);
-    bool import_multisig_main(const std::vector<std::string>& args, bool called_by_mms);
+    bool import_multisig_main(const std::vector<std::string>& args ENABLE_IF_MMS(, bool called_by_mms));
     bool accept_loaded_tx(const tools::wallet2::multisig_tx_set &txs);
     bool sign_multisig(const std::vector<std::string>& args);
-    bool sign_multisig_main(const std::vector<std::string>& args, bool called_by_mms);
+    bool sign_multisig_main(const std::vector<std::string>& args ENABLE_IF_MMS(, bool called_by_mms));
     bool submit_multisig(const std::vector<std::string>& args);
-    bool submit_multisig_main(const std::vector<std::string>& args, bool called_by_mms);
+    bool submit_multisig_main(const std::vector<std::string>& args ENABLE_IF_MMS(, bool called_by_mms));
     bool export_raw_multisig(const std::vector<std::string>& args);
+#ifdef WALLET_ENABLE_MMS
     bool mms(const std::vector<std::string>& args);
+#endif
     bool print_ring(const std::vector<std::string>& args);
     bool set_ring(const std::vector<std::string>& args);
     bool unset_ring(const std::vector<std::string>& args);
@@ -339,7 +341,9 @@ namespace cryptonote
     // idle thread workers
     bool check_inactivity();
     bool check_refresh(bool long_poll_trigger);
+#ifdef WALLET_ENABLE_MMS
     bool check_mms();
+#endif
 
     //----------------- i_wallet2_callback ---------------------
     virtual void on_new_block(uint64_t height, const cryptonote::block& block);
@@ -457,9 +461,11 @@ namespace cryptonote
 
     tools::periodic_task m_inactivity_checker{std::chrono::seconds(0), true /*start_immediately*/, {80 * 1000000, 100 * 1000000}};
     tools::periodic_task m_refresh_checker{std::chrono::seconds(0),    true /*start_immediately*/, {90 * 1000000, 110 * 1000000}};
+
+#ifdef WALLET_ENABLE_MMS
+    // MMS
     tools::periodic_task m_mms_checker{std::chrono::seconds(0),        true /*start_immediately*/, {90 * 1000000, 115 * 1000000}};
 
-    // MMS
     mms::message_store& get_message_store() const { return m_wallet->get_message_store(); };
     mms::multisig_wallet_state get_multisig_wallet_state() const { return m_wallet->get_multisig_wallet_state(); };
     bool mms_active() const { return get_message_store().get_active(); };
@@ -493,5 +499,6 @@ namespace cryptonote
     void mms_start_auto_config(const std::vector<std::string> &args);
     void mms_stop_auto_config(const std::vector<std::string> &args);
     void mms_auto_config(const std::vector<std::string> &args);
+#endif
   };
 }

--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -32,10 +32,20 @@ add_library(wallet
   wallet_args.cpp
   ringdb.cpp
   node_rpc_proxy.cpp
-  message_store.cpp
-  message_transporter.cpp
   transfer_view.cpp
 )
+
+# Unmaintained wallet features, disabled by default
+option(ENABLE_LIGHT_WALLET "Enable (unsupported) light wallet support" OFF)
+option(ENABLE_WALLET_MMS "Enable (unsupported) monero Multisig Messaging System" OFF)
+
+if (ENABLE_LIGHT_WALLET)
+  target_compile_definitions(wallet PUBLIC ENABLE_LIGHT_WALLET)
+endif()
+if (ENABLE_WALLET_MMS)
+  target_compile_definitions(wallet PUBLIC ENABLE_WALLET_MMS)
+  target_sources(wallet PRIVATE message_store.cpp message_transporter.cpp)
+endif()
 
 target_link_libraries(wallet
   PUBLIC

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -111,7 +111,7 @@ public:
     bool store(std::string_view path) override;
     std::string filename() const override;
     std::string keysFilename() const override;
-    bool init(const std::string &daemon_address, uint64_t upper_transaction_size_limit = 0, const std::string &daemon_username = "", const std::string &daemon_password = "", bool use_ssl = false, bool lightWallet = false) override;
+    bool init(const std::string &daemon_address, uint64_t upper_transaction_size_limit = 0, const std::string &daemon_username = "", const std::string &daemon_password = "", bool use_ssl = false ENABLE_IF_LIGHT_WALLET(, bool lightWallet = false)) override;
     bool connectToDaemon() override;
     ConnectionStatus connected() const override;
     void setTrustedDaemon(bool arg) override;
@@ -213,8 +213,10 @@ public:
     void pauseRefresh() override;
     bool parse_uri(const std::string &uri, std::string &address, std::string &payment_id, uint64_t &amount, std::string &tx_description, std::string &recipient_name, std::vector<std::string> &unknown_parameters, std::string &error) override;
     std::string getDefaultDataDir() const override;
+#ifdef ENABLE_LIGHT_WALLET
     bool lightWalletLogin(bool &isNewWallet) const override;
     bool lightWalletImportWalletRequest(std::string &payment_id, uint64_t &fee, bool &new_request, bool &request_fulfilled, std::string &payment_address, std::string &status) override;
+#endif
     bool blackballOutputs(const std::vector<std::string> &outputs, bool add) override;
     bool blackballOutput(const std::string &amount, const std::string &offset) override;
     bool unblackballOutput(const std::string &amount, const std::string &offset) override;

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -528,7 +528,11 @@ struct Wallet
      * \param lightWallet - start wallet in light mode, connect to a openmonero compatible server.
      * \return  - true on success
      */
-    virtual bool init(const std::string &daemon_address, uint64_t upper_transaction_size_limit = 0, const std::string &daemon_username = "", const std::string &daemon_password = "", bool use_ssl = false, bool lightWallet = false) = 0;
+    virtual bool init(const std::string &daemon_address, uint64_t upper_transaction_size_limit = 0, const std::string &daemon_username = "", const std::string &daemon_password = "", bool use_ssl = false
+#ifdef ENABLE_LIGHT_WALLET
+        , bool lightWallet = false
+#endif
+        ) = 0;
 
    /*!
     * \brief createWatchOnly - Creates a watch only wallet
@@ -1015,11 +1019,13 @@ struct Wallet
     //! secondary key reuse mitigation
     virtual void keyReuseMitigation2(bool mitigation) = 0;
 
+#ifdef ENABLE_LIGHT_WALLET
     //! Light wallet authenticate and login
     virtual bool lightWalletLogin(bool &isNewWallet) const = 0;
     
     //! Initiates a light wallet import wallet request
     virtual bool lightWalletImportWalletRequest(std::string &payment_id, uint64_t &fee, bool &new_request, bool &request_fulfilled, std::string &payment_address, std::string &status) = 0;
+#endif
 
     //! locks/unlocks the keys file; returns true on success
     virtual bool lockKeysFile() = 0;

--- a/src/wallet/message_store.h
+++ b/src/wallet/message_store.h
@@ -28,6 +28,10 @@
 
 #pragma once
 
+#ifndef ENABLE_WALLET_MMS
+#error message_storage.h requires -DENABLE_WALLET_MMS
+#endif
+
 #include <cstdlib>
 #include <string>
 #include <vector>

--- a/src/wallet/message_transporter.h
+++ b/src/wallet/message_transporter.h
@@ -27,6 +27,11 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
+
+#ifndef ENABLE_WALLET_MMS
+#error message_storage.h requires -DENABLE_WALLET_MMS
+#endif
+
 #include "epee/serialization/keyvalue_serialization.h"
 #include "cryptonote_basic/cryptonote_basic.h"
 #include "cryptonote_basic/cryptonote_boost_serialization.h"

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -289,7 +289,11 @@ struct options {
   const command_line::arg_descriptor<std::string> extra_entropy = {"extra-entropy", tools::wallet2::tr("File containing extra entropy to initialize the PRNG (any data, aim for 256 bits of entropy to be useful, wihch typically means more than 256 bits of data)")};
 };
 
-void do_prepare_file_names(const fs::path& file_path, fs::path& keys_file, fs::path& wallet_file, fs::path &mms_file)
+void do_prepare_file_names(const fs::path& file_path, fs::path& keys_file, fs::path& wallet_file
+#ifdef WALLET_ENABLE_MMS
+    , fs::path &mms_file
+#endif
+    )
 {
   keys_file = file_path;
   wallet_file = file_path;
@@ -299,7 +303,9 @@ void do_prepare_file_names(const fs::path& file_path, fs::path& keys_file, fs::p
   else // provided wallet file name
     keys_file += ".keys";
 
+#ifdef WALLET_ENABLE_MMS
   (mms_file = keys_file).replace_extension(".mms");
+#endif
 }
 
 uint64_t calculate_fee_from_weight(byte_and_output_fees base_fees, uint64_t weight, uint64_t outputs, uint64_t fee_percent, uint64_t fee_fixed, uint64_t fee_quantization_mask)
@@ -410,7 +416,9 @@ std::unique_ptr<tools::wallet2> make_basic(const boost::program_options::variabl
   wallet->init(std::move(daemon_address), std::move(login), std::move(proxy), 0, trusted_daemon);
   auto ringdb_path = fs::u8path(command_line::get_arg(vm, opts.shared_ringdb_dir));
   wallet->set_ring_database(ringdb_path);
+#ifdef WALLET_ENABLE_MMS
   wallet->get_message_store().set_options(vm);
+#endif
   wallet->device_name(device_name);
   wallet->device_derivation_path(device_derivation_path);
   wallet->m_long_poll_disabled = command_line::get_arg(vm, opts.disable_rpc_long_poll);
@@ -676,20 +684,6 @@ std::pair<std::unique_ptr<tools::wallet2>, tools::password_container> generate_f
   return {nullptr, tools::password_container{}};
 }
 
-std::string strjoin(const std::vector<size_t> &V, const char *sep)
-{
-  std::stringstream ss;
-  bool first = true;
-  for (const auto &v: V)
-  {
-    if (!first)
-      ss << sep;
-    ss << std::to_string(v);
-    first = false;
-  }
-  return ss.str();
-}
-
 bool emplace_or_replace(std::unordered_multimap<crypto::hash, tools::wallet2::pool_payment_details> &container,
   const crypto::hash &key, const tools::wallet2::pool_payment_details &pd)
 {
@@ -893,6 +887,12 @@ bool get_pruned_tx(const rpc::GET_TRANSACTIONS::entry &entry, cryptonote::transa
 namespace tools
 {
 
+const char *wallet2::ERR_MSG_NETWORK_VERSION_QUERY_FAILED = tr("Could not query the current network version, try later");
+const char *wallet2::ERR_MSG_NETWORK_HEIGHT_QUERY_FAILED = tr("Could not query the current network block height, try later: ");
+const char *wallet2::ERR_MSG_SERVICE_NODE_LIST_QUERY_FAILED = tr("Failed to query daemon for service node list");
+const char *wallet2::ERR_MSG_TOO_MANY_TXS_CONSTRUCTED = tr("Constructed too many transations, please sweep_all first");
+const char *wallet2::ERR_MSG_EXCEPTION_THROWN = tr("Exception thrown, staking process could not be completed: ");
+
 const char* wallet2::tr(const char* str) { return i18n_translate(str, "tools::wallet2"); }
 
 gamma_picker::gamma_picker(const std::vector<uint64_t> &rct_offsets, double shape, double scale):
@@ -1064,14 +1064,7 @@ wallet2::wallet2(network_type nettype, uint64_t kdf_rounds, bool unattended):
   m_account_public_address{crypto::null_pkey, crypto::null_pkey},
   m_subaddress_lookahead_major(SUBADDRESS_LOOKAHEAD_MAJOR),
   m_subaddress_lookahead_minor(SUBADDRESS_LOOKAHEAD_MINOR),
-  m_light_wallet(false),
-  m_light_wallet_scanned_block_height(0),
-  m_light_wallet_blockchain_height(0),
-  m_light_wallet_connected(false),
-  m_light_wallet_balance(0),
-  m_light_wallet_unlocked_balance(0),
   m_original_keys_available(false),
-  m_message_store(),
   m_key_device_type(hw::device::device_type::SOFTWARE),
   m_ring_history_saved(false),
   m_ringdb(),
@@ -1155,7 +1148,9 @@ void wallet2::init_options(boost::program_options::options_description& desc_par
   command_line::add_arg(desc_params, opts.regtest);
   command_line::add_arg(desc_params, opts.shared_ringdb_dir);
   command_line::add_arg(desc_params, opts.kdf_rounds);
+#ifdef WALLET_ENABLE_MMS
   mms::message_store::init_options(desc_params);
+#endif
   command_line::add_arg(desc_params, opts.hw_device);
   command_line::add_arg(desc_params, opts.hw_device_derivation_path);
   command_line::add_arg(desc_params, opts.tx_notify);
@@ -1823,6 +1818,7 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
   if (!tx.is_transfer() || tx.version <= txversion::v1)
     return;
 
+  MERROR("PROC NEW TX " << txid);
   PERF_TIMER(process_new_transaction);
   // In this function, tx (probably) only contains the base information
   // (that is, the prunable stuff may or may not be included)
@@ -2117,6 +2113,7 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
                                   error::wallet_internal_error,
                                   "Sanity check failed: An output replacing a unmined blink output must not be from the pool.");
 
+        LOG_ERROR(+transfer.m_spent << " || " << transfer.amount() << " >= " << tx_scan_info[o].amount);
         if (transfer.m_spent || transfer.amount() >= tx_scan_info[o].amount)
         {
           if (transfer.amount() > tx_scan_info[o].amount)
@@ -3429,38 +3426,6 @@ void wallet2::refresh(bool trusted_daemon, uint64_t start_height, uint64_t & blo
     return;
   }
 
-  if(m_light_wallet) {
-
-    // MyMonero get_address_info needs to be called occasionally to trigger wallet sync.
-    // This call is not really needed for other purposes and can be removed if mymonero changes their backend.
-    light_rpc::GET_ADDRESS_INFO::response res{};
-
-    // Get basic info
-    if(light_wallet_get_address_info(res)) {
-      // Last stored block height
-      uint64_t prev_height = m_light_wallet_blockchain_height;
-      // Update lw heights
-      m_light_wallet_scanned_block_height = res.scanned_block_height;
-      m_light_wallet_blockchain_height = res.blockchain_height;
-      // If new height - call new_block callback
-      if(m_light_wallet_blockchain_height != prev_height)
-      {
-        MDEBUG("new block since last time!");
-        m_callback->on_lw_new_block(m_light_wallet_blockchain_height - 1);
-      }
-      m_light_wallet_connected = true;
-      MDEBUG("lw scanned block height: " <<  m_light_wallet_scanned_block_height);
-      MDEBUG("lw blockchain height: " <<  m_light_wallet_blockchain_height);
-      MDEBUG(m_light_wallet_blockchain_height-m_light_wallet_scanned_block_height << " blocks behind");
-      // TODO: add wallet created block info
-
-      light_wallet_get_address_txs();
-    } else
-      m_light_wallet_connected = false;
-
-    // Lighwallet refresh done
-    return;
-  }
   received_money = false;
   blocks_fetched = 0;
   uint64_t added_blocks = 0;
@@ -5573,8 +5538,13 @@ void wallet2::write_watch_only_wallet(const fs::path& wallet_name, const epee::w
 //----------------------------------------------------------------------------------------------------
 void wallet2::wallet_exists(const fs::path& file_path, bool& keys_file_exists, bool& wallet_file_exists)
 {
-  fs::path keys_file, wallet_file, mms_file;
-  do_prepare_file_names(file_path, keys_file, wallet_file, mms_file);
+  fs::path keys_file, wallet_file;
+  [[maybe_unused]] fs::path mms_file;
+  do_prepare_file_names(file_path, keys_file, wallet_file
+#ifdef WALLET_ENABLE_MMS
+      , mms_file
+#endif
+      );
 
   std::error_code ignore;
   keys_file_exists = fs::exists(keys_file, ignore);
@@ -5597,7 +5567,11 @@ bool wallet2::parse_payment_id(std::string_view payment_id_str, crypto::hash& pa
 //----------------------------------------------------------------------------------------------------
 bool wallet2::prepare_file_names(const fs::path& file_path)
 {
-  do_prepare_file_names(file_path, m_keys_file, m_wallet_file, m_mms_file);
+  do_prepare_file_names(file_path, m_keys_file, m_wallet_file
+#ifdef WALLET_ENABLE_MMS
+      , m_mms_file
+#endif
+      );
   return true;
 }
 //----------------------------------------------------------------------------------------------------
@@ -5616,15 +5590,6 @@ bool wallet2::check_connection(rpc::version_t *version, bool *ssl, bool throw_on
     return false;
   }
 
-  // TODO: Add light wallet version check.
-  if(m_light_wallet) {
-      m_rpc_version = 0;
-      if (version)
-        *version = {};
-      if (ssl)
-        *ssl = m_light_wallet_connected; // light wallet is always SSL
-      return m_light_wallet_connected;
-  }
 
   if (ssl)
     *ssl = tools::starts_with(m_http_client.get_base_url(), "https://");
@@ -5822,6 +5787,7 @@ void wallet2::load(const fs::path& wallet_, const epee::wipeable_string& passwor
     MERROR("Failed to save rings, will try again next time");
   }
 
+#ifdef WALLET_ENABLE_MMS
   try
   {
     if (use_fs)
@@ -5831,6 +5797,7 @@ void wallet2::load(const fs::path& wallet_, const epee::wipeable_string& passwor
   {
     MERROR("Failed to initialize MMS, it will be unusable");
   }
+#endif
 }
 //----------------------------------------------------------------------------------------------------
 void wallet2::trim_hashchain()
@@ -5917,7 +5884,6 @@ void wallet2::store_to(const fs::path &path, const epee::wipeable_string &passwo
   const auto& old_keys_file = m_keys_file;
   fs::path old_address_file = m_wallet_file;
   old_address_file += ".address.txt";
-  const auto& old_mms_file = m_mms_file;
 
   // save keys to the new file
   // if we here, main wallet file is saved and we only need to save keys and address files
@@ -5942,9 +5908,11 @@ void wallet2::store_to(const fs::path &path, const epee::wipeable_string &passwo
     // remove old keys file
     if (!fs::remove(old_keys_file, ec))
       LOG_ERROR("error removing file: " << old_keys_file << ": " << ec.message());
+#ifdef WALLET_ENABLE_MMS
     // remove old message store file
-    if (fs::exists(old_mms_file, ec) && !fs::remove(old_mms_file, ec))
-      LOG_ERROR("error removing file: " << old_mms_file << ": " << ec.message());
+    if (fs::exists(m_mms_file, ec) && !fs::remove(m_mms_file, ec))
+      LOG_ERROR("error removing file: " << m_mms_file << ": " << ec.message());
+#endif
   } else {
     // save to new file
     fs::path new_file = m_wallet_file;
@@ -5970,12 +5938,14 @@ void wallet2::store_to(const fs::path &path, const epee::wipeable_string &passwo
     THROW_WALLET_EXCEPTION_IF(e, error::file_save_error, m_wallet_file, e);
   }
 
+#ifdef WALLET_ENABLE_MMS
   if (m_message_store.get_active())
   {
     // While the "m_message_store" object of course always exist, a file for the message
     // store should only exist if the MMS is really active
     m_message_store.write_to_file(get_multisig_wallet_state(), m_mms_file);
   }
+#endif
 }
 //----------------------------------------------------------------------------------------------------
 std::optional<wallet2::cache_file_data> wallet2::get_cache_file_data(const epee::wipeable_string &passwords)
@@ -6005,8 +5975,10 @@ std::optional<wallet2::cache_file_data> wallet2::get_cache_file_data(const epee:
 uint64_t wallet2::balance(uint32_t index_major, bool strict) const
 {
   uint64_t amount = 0;
+#ifdef ENABLE_LIGHT_WALLET
   if(m_light_wallet)
     return m_light_wallet_unlocked_balance;
+#endif
   for (const auto& i : balance_per_subaddress(index_major, strict))
     amount += i.second;
   return amount;
@@ -6019,8 +5991,10 @@ uint64_t wallet2::unlocked_balance(uint32_t index_major, bool strict, uint64_t *
     *blocks_to_unlock = 0;
   if (time_to_unlock)
     *time_to_unlock = 0;
+#ifdef ENABLE_LIGHT_WALLET
   if(m_light_wallet)
     return m_light_wallet_balance;
+#endif
   for (const auto& i : unlocked_balance_per_subaddress(index_major, strict))
   {
     amount += i.second.first;
@@ -6963,6 +6937,7 @@ crypto::hash wallet2::get_payment_id(const pending_tx &ptx) const
 // take a pending tx and actually send it to the daemon
 void wallet2::commit_tx(pending_tx& ptx, bool blink)
 {
+#ifdef ENABLE_LIGHT_WALLET
   if(m_light_wallet)
   {
     light_rpc::SUBMIT_RAW_TX::request oreq{};
@@ -6976,6 +6951,9 @@ void wallet2::commit_tx(pending_tx& ptx, bool blink)
     // MyMonero and OpenMonero use different status strings
     THROW_WALLET_EXCEPTION_IF(ores.status != "OK" && ores.status != "success" , error::tx_rejected, ptx.tx, get_rpc_status(ores.status), ores.error);
   }
+#else
+  if (false) {}
+#endif
   else
   {
     // Normal submit
@@ -7834,10 +7812,12 @@ byte_and_output_fees wallet2::get_base_fees() const
 //----------------------------------------------------------------------------------------------------
 uint64_t wallet2::get_fee_quantization_mask() const
 {
+#ifdef ENABLE_LIGHT_WALLET
   if(m_light_wallet)
   {
     return 1; // TODO
   }
+#endif
 
   uint64_t fee_quantization_mask;
   if (m_node_rpc_proxy.get_fee_quantization_mask(fee_quantization_mask))
@@ -9119,109 +9099,6 @@ bool wallet2::tx_add_fake_output(std::vector<std::vector<tools::wallet2::get_out
   return true;
 }
 
-void wallet2::light_wallet_get_outs(std::vector<std::vector<tools::wallet2::get_outs_entry>> &outs, const std::vector<size_t> &selected_transfers, size_t fake_outputs_count) {
-
-  MDEBUG("LIGHTWALLET - Getting random outs");
-
-  light_rpc::GET_RANDOM_OUTS::request oreq{};
-  light_rpc::GET_RANDOM_OUTS::response ores{};
-
-  size_t light_wallet_requested_outputs_count = (size_t)((fake_outputs_count + 1) * 1.5 + 1);
-
-  // Amounts to ask for
-  // MyMonero api handle amounts and fees as strings
-  for(size_t idx: selected_transfers) {
-    const uint64_t ask_amount = m_transfers[idx].is_rct() ? 0 : m_transfers[idx].amount();
-    std::ostringstream amount_ss;
-    amount_ss << ask_amount;
-    oreq.amounts.push_back(amount_ss.str());
-  }
-
-  oreq.count = light_wallet_requested_outputs_count;
-  bool r = invoke_http<light_rpc::GET_RANDOM_OUTS>(oreq, ores);
-  THROW_WALLET_EXCEPTION_IF(!r, error::no_connection_to_daemon, "get_random_outs");
-  THROW_WALLET_EXCEPTION_IF(ores.amount_outs.empty() , error::wallet_internal_error, "No outputs received from light wallet node. Error: " + ores.Error);
-
-  // Check if we got enough outputs for each amount
-  for(auto& out: ores.amount_outs) {
-    const uint64_t out_amount = boost::lexical_cast<uint64_t>(out.amount);
-    THROW_WALLET_EXCEPTION_IF(out.outputs.size() < light_wallet_requested_outputs_count , error::wallet_internal_error, "Not enough outputs for amount: " + boost::lexical_cast<std::string>(out.amount));
-    MDEBUG(out.outputs.size() << " outputs for amount "+ boost::lexical_cast<std::string>(out.amount) + " received from light wallet node");
-  }
-
-  MDEBUG("selected transfers size: " << selected_transfers.size());
-
-  for(size_t idx: selected_transfers)
-  {
-    // Create new index
-    outs.push_back(std::vector<get_outs_entry>());
-    outs.back().reserve(fake_outputs_count + 1);
-
-    // add real output first
-    const transfer_details &td = m_transfers[idx];
-    const uint64_t amount = td.is_rct() ? 0 : td.amount();
-    outs.back().push_back(std::make_tuple(td.m_global_output_index, td.get_public_key(), rct::commit(td.amount(), td.m_mask)));
-    MDEBUG("added real output " << tools::type_to_hex(td.get_public_key()));
-
-    // Even if the lightwallet server returns random outputs, we pick them randomly.
-    std::vector<size_t> order;
-    order.resize(light_wallet_requested_outputs_count);
-    for (size_t n = 0; n < order.size(); ++n)
-      order[n] = n;
-    std::shuffle(order.begin(), order.end(), crypto::random_device{});
-
-
-    LOG_PRINT_L2("Looking for " << (fake_outputs_count+1) << " outputs with amounts " << print_money(td.is_rct() ? 0 : td.amount()));
-    MDEBUG("OUTS SIZE: " << outs.back().size());
-    for (size_t o = 0; o < light_wallet_requested_outputs_count && outs.back().size() < fake_outputs_count + 1; ++o)
-    {
-      // Random pick
-      size_t i = order[o];
-
-      // Find which random output key to use
-      bool found_amount = false;
-      size_t amount_key;
-      for(amount_key = 0; amount_key < ores.amount_outs.size(); ++amount_key)
-      {
-        if(boost::lexical_cast<uint64_t>(ores.amount_outs[amount_key].amount) == amount) {
-          found_amount = true;
-          break;
-        }
-      }
-      THROW_WALLET_EXCEPTION_IF(!found_amount , error::wallet_internal_error, "Outputs for amount " + boost::lexical_cast<std::string>(ores.amount_outs[amount_key].amount) + " not found" );
-
-      LOG_PRINT_L2("Index " << i << "/" << light_wallet_requested_outputs_count << ": idx " << ores.amount_outs[amount_key].outputs[i].global_index << " (real " << td.m_global_output_index << "), unlocked " << "(always in light)" << ", key " << ores.amount_outs[0].outputs[i].public_key);
-
-      // Convert light wallet string data to proper data structures
-      crypto::public_key tx_public_key;
-      rct::key mask{}; // decrypted mask - not used here
-      rct::key rct_commit{};
-      const auto& pkey = ores.amount_outs[amount_key].outputs[i].public_key;
-      THROW_WALLET_EXCEPTION_IF(pkey.size() != 64 || !oxenmq::is_hex(pkey), error::wallet_internal_error, "Invalid public_key");
-      tools::hex_to_type(ores.amount_outs[amount_key].outputs[i].public_key, tx_public_key);
-      const uint64_t global_index = ores.amount_outs[amount_key].outputs[i].global_index;
-      if(!light_wallet_parse_rct_str(ores.amount_outs[amount_key].outputs[i].rct, tx_public_key, 0, mask, rct_commit, false))
-        rct_commit = rct::zeroCommit(td.amount());
-
-      if (tx_add_fake_output(outs, global_index, tx_public_key, rct_commit, td.m_global_output_index, true)) {
-        MDEBUG("added fake output " << ores.amount_outs[amount_key].outputs[i].public_key);
-        MDEBUG("index " << global_index);
-      }
-    }
-
-    THROW_WALLET_EXCEPTION_IF(outs.back().size() < fake_outputs_count + 1 , error::wallet_internal_error, "Not enough fake outputs found" );
-
-    // Real output is the first. Shuffle outputs
-    MTRACE(outs.back().size() << " outputs added. Sorting outputs by index:");
-    std::sort(outs.back().begin(), outs.back().end(), [](const get_outs_entry &a, const get_outs_entry &b) { return std::get<0>(a) < std::get<0>(b); });
-
-    // Print output order
-    for(auto added_out: outs.back())
-      MTRACE(std::get<0>(added_out));
-
-  }
-}
-
 std::pair<std::set<uint64_t>, size_t> outs_unique(const std::vector<std::vector<tools::wallet2::get_outs_entry>> &outs)
 {
   std::set<uint64_t> unique;
@@ -9269,10 +9146,12 @@ void wallet2::get_outs(std::vector<std::vector<tools::wallet2::get_outs_entry>> 
   LOG_PRINT_L2("fake_outputs_count: " << fake_outputs_count);
   outs.clear();
 
+#ifdef ENABLE_LIGHT_WALLET
   if(m_light_wallet && fake_outputs_count > 0) {
     light_wallet_get_outs(outs, selected_transfers, fake_outputs_count);
     return;
   }
+#endif
 
   if (fake_outputs_count > 0)
   {
@@ -9898,7 +9777,7 @@ void wallet2::transfer_selected_rct(std::vector<cryptonote::tx_destination_entry
   uint64_t upper_transaction_weight_limit = get_upper_transaction_weight_limit();
   uint64_t needed_money = fee;
   LOG_PRINT_L2("transfer_selected_rct: starting with fee " << print_money (needed_money));
-  LOG_PRINT_L2("selected transfers: " << strjoin(selected_transfers, " "));
+  LOG_PRINT_L2("selected transfers: " << tools::join(" ", selected_transfers));
 
   // calculate total amount being sent to all destinations
   // throw if total amount overflows uint64_t
@@ -10359,6 +10238,110 @@ static uint32_t get_count_above(const std::vector<wallet2::transfer_details> &tr
     if (transfers[idx].amount() >= threshold)
       ++count;
   return count;
+}
+
+#ifdef ENABLE_LIGHT_WALLET
+void wallet2::light_wallet_get_outs(std::vector<std::vector<tools::wallet2::get_outs_entry>> &outs, const std::vector<size_t> &selected_transfers, size_t fake_outputs_count) {
+
+  MDEBUG("LIGHTWALLET - Getting random outs");
+
+  light_rpc::GET_RANDOM_OUTS::request oreq{};
+  light_rpc::GET_RANDOM_OUTS::response ores{};
+
+  size_t light_wallet_requested_outputs_count = (size_t)((fake_outputs_count + 1) * 1.5 + 1);
+
+  // Amounts to ask for
+  // MyMonero api handle amounts and fees as strings
+  for(size_t idx: selected_transfers) {
+    const uint64_t ask_amount = m_transfers[idx].is_rct() ? 0 : m_transfers[idx].amount();
+    std::ostringstream amount_ss;
+    amount_ss << ask_amount;
+    oreq.amounts.push_back(amount_ss.str());
+  }
+
+  oreq.count = light_wallet_requested_outputs_count;
+  bool r = invoke_http<light_rpc::GET_RANDOM_OUTS>(oreq, ores);
+  THROW_WALLET_EXCEPTION_IF(!r, error::no_connection_to_daemon, "get_random_outs");
+  THROW_WALLET_EXCEPTION_IF(ores.amount_outs.empty() , error::wallet_internal_error, "No outputs received from light wallet node. Error: " + ores.Error);
+
+  // Check if we got enough outputs for each amount
+  for(auto& out: ores.amount_outs) {
+    const uint64_t out_amount = boost::lexical_cast<uint64_t>(out.amount);
+    THROW_WALLET_EXCEPTION_IF(out.outputs.size() < light_wallet_requested_outputs_count , error::wallet_internal_error, "Not enough outputs for amount: " + boost::lexical_cast<std::string>(out.amount));
+    MDEBUG(out.outputs.size() << " outputs for amount "+ boost::lexical_cast<std::string>(out.amount) + " received from light wallet node");
+  }
+
+  MDEBUG("selected transfers size: " << selected_transfers.size());
+
+  for(size_t idx: selected_transfers)
+  {
+    // Create new index
+    outs.push_back(std::vector<get_outs_entry>());
+    outs.back().reserve(fake_outputs_count + 1);
+
+    // add real output first
+    const transfer_details &td = m_transfers[idx];
+    const uint64_t amount = td.is_rct() ? 0 : td.amount();
+    outs.back().push_back(std::make_tuple(td.m_global_output_index, td.get_public_key(), rct::commit(td.amount(), td.m_mask)));
+    MDEBUG("added real output " << tools::type_to_hex(td.get_public_key()));
+
+    // Even if the lightwallet server returns random outputs, we pick them randomly.
+    std::vector<size_t> order;
+    order.resize(light_wallet_requested_outputs_count);
+    for (size_t n = 0; n < order.size(); ++n)
+      order[n] = n;
+    std::shuffle(order.begin(), order.end(), crypto::random_device{});
+
+
+    LOG_PRINT_L2("Looking for " << (fake_outputs_count+1) << " outputs with amounts " << print_money(td.is_rct() ? 0 : td.amount()));
+    MDEBUG("OUTS SIZE: " << outs.back().size());
+    for (size_t o = 0; o < light_wallet_requested_outputs_count && outs.back().size() < fake_outputs_count + 1; ++o)
+    {
+      // Random pick
+      size_t i = order[o];
+
+      // Find which random output key to use
+      bool found_amount = false;
+      size_t amount_key;
+      for(amount_key = 0; amount_key < ores.amount_outs.size(); ++amount_key)
+      {
+        if(boost::lexical_cast<uint64_t>(ores.amount_outs[amount_key].amount) == amount) {
+          found_amount = true;
+          break;
+        }
+      }
+      THROW_WALLET_EXCEPTION_IF(!found_amount , error::wallet_internal_error, "Outputs for amount " + boost::lexical_cast<std::string>(ores.amount_outs[amount_key].amount) + " not found" );
+
+      LOG_PRINT_L2("Index " << i << "/" << light_wallet_requested_outputs_count << ": idx " << ores.amount_outs[amount_key].outputs[i].global_index << " (real " << td.m_global_output_index << "), unlocked " << "(always in light)" << ", key " << ores.amount_outs[0].outputs[i].public_key);
+
+      // Convert light wallet string data to proper data structures
+      crypto::public_key tx_public_key;
+      rct::key mask{}; // decrypted mask - not used here
+      rct::key rct_commit{};
+      const auto& pkey = ores.amount_outs[amount_key].outputs[i].public_key;
+      THROW_WALLET_EXCEPTION_IF(pkey.size() != 64 || !oxenmq::is_hex(pkey), error::wallet_internal_error, "Invalid public_key");
+      tools::hex_to_type(ores.amount_outs[amount_key].outputs[i].public_key, tx_public_key);
+      const uint64_t global_index = ores.amount_outs[amount_key].outputs[i].global_index;
+      if(!light_wallet_parse_rct_str(ores.amount_outs[amount_key].outputs[i].rct, tx_public_key, 0, mask, rct_commit, false))
+        rct_commit = rct::zeroCommit(td.amount());
+
+      if (tx_add_fake_output(outs, global_index, tx_public_key, rct_commit, td.m_global_output_index, true)) {
+        MDEBUG("added fake output " << ores.amount_outs[amount_key].outputs[i].public_key);
+        MDEBUG("index " << global_index);
+      }
+    }
+
+    THROW_WALLET_EXCEPTION_IF(outs.back().size() < fake_outputs_count + 1 , error::wallet_internal_error, "Not enough fake outputs found" );
+
+    // Real output is the first. Shuffle outputs
+    MTRACE(outs.back().size() << " outputs added. Sorting outputs by index:");
+    std::sort(outs.back().begin(), outs.back().end(), [](const get_outs_entry &a, const get_outs_entry &b) { return std::get<0>(a) < std::get<0>(b); });
+
+    // Print output order
+    for(auto added_out: outs.back())
+      MTRACE(std::get<0>(added_out));
+
+  }
 }
 
 bool wallet2::light_wallet_login(bool &new_address)
@@ -10826,6 +10809,7 @@ bool wallet2::light_wallet_key_image_is_ours(const crypto::key_image& key_image,
   m_key_image_cache.emplace(tx_public_key, index_keyimage_map);
   return key_image == calculated_key_image;
 }
+#endif
 
 // Another implementation of transaction creation that is hopefully better
 // While there is anything left to pay, it goes through random outputs and tries
@@ -10857,14 +10841,16 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
     dsts.emplace_back(0, account_public_address{} /*address*/, false /*is_subaddress*/); // NOTE: Create a dummy dest that gets repurposed into the change output.
   }
 
+#ifdef ENABLE_LIGHT_WALLET
   if(m_light_wallet) {
     // Populate m_transfers
     light_wallet_get_unspent_outs();
   }
+#endif
   std::vector<std::pair<uint32_t, std::vector<size_t>>> unused_transfers_indices_per_subaddr;
   std::vector<std::pair<uint32_t, std::vector<size_t>>> unused_dust_indices_per_subaddr;
   uint64_t needed_money;
-  uint64_t accumulated_fee, accumulated_outputs, accumulated_change;
+  uint64_t accumulated_fee, accumulated_change;
   struct TX {
     std::vector<size_t> selected_transfers;
     std::vector<cryptonote::tx_destination_entry> dsts;
@@ -11062,7 +11048,6 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
   // start with an empty tx
   txes.push_back(TX());
   accumulated_fee = 0;
-  accumulated_outputs = 0;
   accumulated_change = 0;
   adding_fee = false;
   needed_fee = 0;
@@ -11075,8 +11060,6 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
   // the destination, and one for change.
   LOG_PRINT_L2("checking preferred");
   std::vector<size_t> preferred_inputs;
-  uint64_t rct_outs_needed = 2 * (fake_outs_count + 1);
-  rct_outs_needed += 100; // some fudge factor since we don't know how many are locked
   {
     // this is used to build a tx that's 1 or 2 inputs, and 1 or 2 outputs, which will get us a known fee.
     uint64_t estimated_fee = estimate_fee(2, fake_outs_count, min_outputs, extra.size(), clsag, base_fee, fee_percent, fixed_fee, fee_quantization_mask);
@@ -11122,8 +11105,8 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
     TX &tx = txes.back();
 
     LOG_PRINT_L2("Start of loop with " << unused_transfers_indices->size() << " " << unused_dust_indices->size() << ", tx.dsts.size() " << tx.dsts.size());
-    LOG_PRINT_L2("unused_transfers_indices: " << strjoin(*unused_transfers_indices, " "));
-    LOG_PRINT_L2("unused_dust_indices: " << strjoin(*unused_dust_indices, " "));
+    LOG_PRINT_L2("unused_transfers_indices: " << tools::join(" ", *unused_transfers_indices));
+    LOG_PRINT_L2("unused_dust_indices: " << tools::join(" ", *unused_dust_indices));
     LOG_PRINT_L2("dsts size " << dsts.size() << ", first " << (dsts.empty() ? "-" : cryptonote::print_money(dsts[0].amount)));
     LOG_PRINT_L2("adding_fee " << adding_fee);
 
@@ -11184,7 +11167,6 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
     // add this output to the list to spend
     tx.selected_transfers.push_back(idx);
     uint64_t available_amount = td.amount();
-    accumulated_outputs += available_amount;
 
     // clear any fake outs we'd already gathered, since we'll need a new set
     outs.clear();
@@ -11852,9 +11834,11 @@ void wallet2::get_hard_fork_info(uint8_t version, uint64_t &earliest_height) con
 //----------------------------------------------------------------------------------------------------
 bool wallet2::use_fork_rules(uint8_t version, uint64_t early_blocks) const
 {
+#ifdef ENABLE_LIGHT_WALLET
   // TODO: How to get fork rule info from light wallet node?
   if(m_light_wallet)
     return true;
+#endif
   uint64_t height, earliest_height{0};
   if (!m_node_rpc_proxy.get_height(height))
     THROW_WALLET_EXCEPTION(tools::error::no_connection_to_daemon, __func__);
@@ -14411,9 +14395,7 @@ std::string wallet2::make_uri(const std::string &address, const std::string &pay
   return uri;
 }
 
-namespace {
-
-std::string uri_decode(std::string_view encoded)
+static std::string uri_decode(std::string_view encoded)
 {
   std::string decoded;
   for (auto it = encoded.begin(); it != encoded.end(); )
@@ -14427,8 +14409,6 @@ std::string uri_decode(std::string_view encoded)
       decoded += *it++;
   }
   return decoded;
-}
-
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -14679,6 +14659,7 @@ bool wallet2::generate_signature_for_request_stake_unlock(const crypto::key_imag
       error::wallet_internal_error, "Hardware device failed to sign the unlock request");
   return true;
 }
+#ifdef WALLET_ENABLE_MMS
 //----------------------------------------------------------------------------------------------------
 mms::multisig_wallet_state wallet2::get_multisig_wallet_state() const
 {
@@ -14702,6 +14683,7 @@ mms::multisig_wallet_state wallet2::get_multisig_wallet_state() const
   state.mms_file=m_mms_file;
   return state;
 }
+#endif
 //----------------------------------------------------------------------------------------------------
 wallet_device_callback * wallet2::get_device_callback()
 {

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -1048,7 +1048,7 @@ namespace tools
       uint32_t priority = convert_priority(req.priority);
       std::optional<uint8_t> hf_version = m_wallet->get_hard_fork_version();
       if (!hf_version)
-        throw wallet_rpc_error{error_code::HF_QUERY_FAILED, tools::ERR_MSG_NETWORK_VERSION_QUERY_FAILED};
+        throw wallet_rpc_error{error_code::HF_QUERY_FAILED, tools::wallet2::ERR_MSG_NETWORK_VERSION_QUERY_FAILED};
       cryptonote::oxen_construct_tx_params tx_params = tools::wallet2::construct_params(*hf_version, cryptonote::txtype::standard, priority);
       std::vector<wallet2::pending_tx> ptx_vector = m_wallet->create_transactions_2(dsts, CRYPTONOTE_DEFAULT_TX_MIXIN, req.unlock_time, priority, extra, req.account_index, req.subaddr_indices, tx_params);
 
@@ -1082,7 +1082,7 @@ namespace tools
       uint32_t priority = convert_priority(req.priority);
       std::optional<uint8_t> hf_version = m_wallet->get_hard_fork_version();
       if (!hf_version)
-        throw wallet_rpc_error{error_code::HF_QUERY_FAILED, tools::ERR_MSG_NETWORK_VERSION_QUERY_FAILED};
+        throw wallet_rpc_error{error_code::HF_QUERY_FAILED, tools::wallet2::ERR_MSG_NETWORK_VERSION_QUERY_FAILED};
 
       cryptonote::oxen_construct_tx_params tx_params = tools::wallet2::construct_params(*hf_version, cryptonote::txtype::standard, priority);
       LOG_PRINT_L2("on_transfer_split calling create_transactions_2");
@@ -3233,7 +3233,7 @@ namespace {
     std::string reason;
     ons::mapping_type type;
     std::optional<uint8_t> hf_version = m_wallet->get_hard_fork_version();
-    if (!hf_version) throw wallet_rpc_error{error_code::HF_QUERY_FAILED, tools::ERR_MSG_NETWORK_VERSION_QUERY_FAILED};
+    if (!hf_version) throw wallet_rpc_error{error_code::HF_QUERY_FAILED, tools::wallet2::ERR_MSG_NETWORK_VERSION_QUERY_FAILED};
     if (!ons::validate_mapping_type(req.type, *hf_version, ons::ons_tx_type::update, &type, &reason))
       throw wallet_rpc_error{error_code::WRONG_ONS_TYPE, "Wrong ons type given=" + reason};
 
@@ -3260,7 +3260,7 @@ namespace {
     std::string reason;
     ons::mapping_type type;
     std::optional<uint8_t> hf_version = m_wallet->get_hard_fork_version();
-    if (!hf_version) throw wallet_rpc_error{error_code::HF_QUERY_FAILED, tools::ERR_MSG_NETWORK_VERSION_QUERY_FAILED};
+    if (!hf_version) throw wallet_rpc_error{error_code::HF_QUERY_FAILED, tools::wallet2::ERR_MSG_NETWORK_VERSION_QUERY_FAILED};
     if (!ons::validate_mapping_type(req.type, *hf_version, ons::ons_tx_type::lookup, &type, &reason))
       throw wallet_rpc_error{error_code::WRONG_ONS_TYPE, "Wrong ons type given=" + reason};
 
@@ -3368,7 +3368,7 @@ namespace {
     require_open();
 
     std::optional<uint8_t> hf_version = m_wallet->get_hard_fork_version();
-    if (!hf_version) throw wallet_rpc_error{error_code::HF_QUERY_FAILED, tools::ERR_MSG_NETWORK_VERSION_QUERY_FAILED};
+    if (!hf_version) throw wallet_rpc_error{error_code::HF_QUERY_FAILED, tools::wallet2::ERR_MSG_NETWORK_VERSION_QUERY_FAILED};
 
     std::string reason;
     for (auto& rec : req.names)
@@ -3415,7 +3415,7 @@ namespace {
     ons::mapping_type type = {};
 
     std::optional<uint8_t> hf_version = m_wallet->get_hard_fork_version();
-    if (!hf_version) throw wallet_rpc_error{error_code::HF_QUERY_FAILED, tools::ERR_MSG_NETWORK_VERSION_QUERY_FAILED};
+    if (!hf_version) throw wallet_rpc_error{error_code::HF_QUERY_FAILED, tools::wallet2::ERR_MSG_NETWORK_VERSION_QUERY_FAILED};
     {
       if (!ons::validate_mapping_type(req.type, *hf_version, ons::ons_tx_type::lookup, &type, &reason))
         throw wallet_rpc_error{error_code::WRONG_ONS_TYPE, "Invalid ONS type: " + reason};
@@ -3450,7 +3450,7 @@ namespace {
 
     std::string reason;
     std::optional<uint8_t> hf_version = m_wallet->get_hard_fork_version();
-    if (!hf_version) throw wallet_rpc_error{error_code::HF_QUERY_FAILED, tools::ERR_MSG_NETWORK_VERSION_QUERY_FAILED};
+    if (!hf_version) throw wallet_rpc_error{error_code::HF_QUERY_FAILED, tools::wallet2::ERR_MSG_NETWORK_VERSION_QUERY_FAILED};
 
     ons::mapping_type type;
     if (!ons::validate_mapping_type(req.type, *hf_version, ons::ons_tx_type::lookup, &type, &reason))


### PR DESCRIPTION
This aren't used or supported by anyone in Oxen land (as far as I know)
and have not been maintained since the beginning, so hide them behind
disabled-by-default cmake options.

This cuts about 10% off the wallet2 compilation time and 3% off the
simplewallet compilation time, plus gets rid of the page of mms crap in
the cli wallet's "help" screen.