### PR TITLE
Add fmtlib::fmt backport of C++20 std::format

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,6 @@
 [submodule "external/ghc-filesystem"]
 	path = external/ghc-filesystem
 	url = https://github.com/gulrak/filesystem.git
+[submodule "external/fmt"]
+	path = external/fmt
+	url = https://github.com/fmtlib/fmt.git

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -83,6 +83,7 @@ endif()
 add_subdirectory(db_drivers)
 add_subdirectory(easylogging++ easyloggingpp)
 add_subdirectory(randomx EXCLUDE_FROM_ALL)
+add_subdirectory(fmt)
 
 # uSockets doesn't really have a proper build system (just a very simple Makefile) so build it
 # ourselves.

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -28,7 +28,6 @@
 
 #include "db_lmdb.h"
 
-#include <boost/format.hpp>
 #include <boost/circular_buffer.hpp>
 #include <boost/endian/conversion.hpp>
 #include <memory>
@@ -712,7 +711,7 @@ bool BlockchainLMDB::need_resize(uint64_t threshold_size) const
   MDEBUG("Space remaining: " << mei.me_mapsize - size_used);
   MDEBUG("Size threshold:  " << threshold_size);
   float resize_percent = RESIZE_PERCENT;
-  MDEBUG(boost::format("Percent used: %.04f  Percent threshold: %.04f") % (100.*size_used/mei.me_mapsize) % (100.*resize_percent));
+  MDEBUG("Percent used: " << 100.*size_used/mei.me_mapsize << "  Percent threshold: " << 100.*resize_percent);
 
   if (threshold_size > 0)
   {

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -66,6 +66,7 @@ target_link_libraries(common
     cncrypto
     oxenmq::oxenmq
     filesystem
+    fmt::fmt
   PRIVATE
     libunbound
     OpenSSL::SSL

--- a/src/gen_multisig/gen_multisig.cpp
+++ b/src/gen_multisig/gen_multisig.cpp
@@ -38,7 +38,7 @@
 #include <sstream>
 #include <boost/program_options.hpp>
 #include <boost/algorithm/string.hpp>
-#include <boost/format.hpp>
+#include <fmt/core.h>
 #include "crypto/crypto.h"  // for crypto::secret_key definition
 #include "common/i18n.h"
 #include "common/command_line.h"
@@ -78,7 +78,7 @@ namespace
 
 static bool generate_multisig(uint32_t threshold, uint32_t total, const fs::path& basename, network_type nettype, bool create_address_file)
 {
-  tools::msg_writer() << (boost::format(genms::tr("Generating %u %u/%u multisig wallets")) % total % threshold % total).str();
+  tools::msg_writer() << fmt::format(genms::tr("Generating {:d} {:d}/{:d} multisig wallets"), total, threshold, total);
 
   const auto pwd_container = tools::password_container::prompt(true, "Enter password for new multisig wallets");
 
@@ -227,7 +227,7 @@ int main(int argc, char* argv[])
   }
   if (threshold <= 1 || threshold > total)
   {
-    tools::fail_msg_writer() << (boost::format(genms::tr("Error: expected N > 1 and N <= M, but got N==%u and M==%d")) % threshold % total).str();
+    tools::fail_msg_writer() << fmt::format(genms::tr("Error: expected N > 1 and N <= M, but got N=={:d} and M=={:d}"), threshold, total);
     return 1;
   }
   fs::path basename;


### PR DESCRIPTION
Because I'm tired of waiting for std::format.

(Cherry-picked this out of PR #1477 so that we can easily cherry-pick it into other PRs where it can be useful before that PR is ready).