### PR TITLE
CI Build fix - sizeof uptime proof & disable GUI builds

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -208,18 +208,18 @@ local gui_wallet_step_darwin = {
     debian_pipeline("Static (bionic amd64)", "ubuntu:bionic", deps='g++-8 '+static_build_deps,
                     cmake_extra='-DBUILD_STATIC_DEPS=ON -DCMAKE_C_COMPILER=gcc-8 -DCMAKE_CXX_COMPILER=g++-8 -DARCH=x86-64',
                     build_tests=false, lto=true, extra_cmds=static_check_and_upload,
-                    extra_steps=[gui_wallet_step('ubuntu:bionic')]),
+                    /*extra_steps=[gui_wallet_step('ubuntu:bionic')]*/),
 
     // Static mingw build (on focal) which gets uploaded to builds.lokinet.dev:
     debian_pipeline("Static (win64)", "ubuntu:focal", deps='g++ g++-mingw-w64-x86-64 '+static_build_deps,
                     cmake_extra='-DCMAKE_TOOLCHAIN_FILE=../cmake/64-bit-toolchain.cmake -DBUILD_STATIC_DEPS=ON -DARCH=x86-64',
                     build_tests=false, lto=false, test_oxend=false, extra_cmds=[
                         'ninja strip_binaries', 'ninja create_zip', '../utils/build_scripts/drone-static-upload.sh'],
-                    extra_steps=[gui_wallet_step('debian:stable', wine=true)]),
+                    /*extra_steps=[gui_wallet_step('debian:stable', wine=true)]*/),
 
     // Macos builds:
     mac_builder('macOS (Static)', cmake_extra='-DBUILD_STATIC_DEPS=ON -DARCH=core2 -DARCH_ID=amd64',
-                build_tests=false, lto=true, extra_cmds=static_check_and_upload, extra_steps=[gui_wallet_step_darwin]),
+                build_tests=false, lto=true, extra_cmds=static_check_and_upload, /*extra_steps=[gui_wallet_step_darwin]*/),
     mac_builder('macOS (Release)', run_tests=true),
     mac_builder('macOS (Debug)', build_type='Debug', cmake_extra='-DBUILD_DEBUG_UTILS=ON'),
 

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -38,6 +38,7 @@
 #include "cryptonote_core/service_node_voting.h"
 #include "cryptonote_core/service_node_quorum_cop.h"
 #include "common/util.h"
+#include "uptime_proof.h"
 
 namespace cryptonote
 {
@@ -45,11 +46,6 @@ class Blockchain;
 class BlockchainDB;
 struct checkpoint_t;
 }; // namespace cryptonote
-
-namespace uptime_proof
-{
-  class Proof;
-}
 
 namespace service_nodes
 {

--- a/src/cryptonote_core/uptime_proof.cpp
+++ b/src/cryptonote_core/uptime_proof.cpp
@@ -139,9 +139,7 @@ cryptonote::NOTIFY_BTENCODED_UPTIME_PROOF::request Proof::generate_request() con
   return request;
 }
 
-}
-
-bool operator==(const uptime_proof::Proof& lhs, const uptime_proof::Proof& rhs)
+bool operator==(const Proof& lhs, const Proof& rhs)
 {
    bool result = true;
 
@@ -162,8 +160,9 @@ bool operator==(const uptime_proof::Proof& lhs, const uptime_proof::Proof& rhs)
    return result;
 }
 
-bool operator!=(const uptime_proof::Proof& lhs, const uptime_proof::Proof& rhs)
+bool operator!=(const Proof& lhs, const Proof& rhs)
 {
   return !(lhs == rhs);
 }
 
+}

--- a/src/cryptonote_core/uptime_proof.cpp
+++ b/src/cryptonote_core/uptime_proof.cpp
@@ -1,4 +1,5 @@
 #include "uptime_proof.h"
+#include "service_node_list.h"
 #include "common/string_util.h"
 #include "version.h"
 

--- a/src/cryptonote_core/uptime_proof.h
+++ b/src/cryptonote_core/uptime_proof.h
@@ -41,6 +41,7 @@ public:
   cryptonote::NOTIFY_BTENCODED_UPTIME_PROOF::request generate_request() const;
 };
 
+bool operator==(const Proof& lhs, const Proof& rhs);
+bool operator!=(const Proof& lhs, const Proof& rhs);
+
 }
-bool operator==(const uptime_proof::Proof& lhs, const uptime_proof::Proof& rhs);
-bool operator!=(const uptime_proof::Proof& lhs, const uptime_proof::Proof& rhs);

--- a/src/cryptonote_core/uptime_proof.h
+++ b/src/cryptonote_core/uptime_proof.h
@@ -1,8 +1,13 @@
 #pragma once
 
-#include "service_node_list.h"
-#include "../cryptonote_protocol/cryptonote_protocol_defs.h"
+#include "cryptonote_protocol/cryptonote_protocol_defs.h"
 #include <oxenmq/bt_serialize.h>
+
+namespace service_nodes {
+
+struct service_node_keys;
+
+}
 
 namespace uptime_proof
 {


### PR DESCRIPTION
- gcc-8 is struggling with the uptime_proof forward declaration, so rearrange it so that it works.
- minor namespace move of Proof `==` comparison
- Disable failing GUI wallet builds for now so that we can get reliable CI indicators again (until we figure out why they are failing and correct them).