### PR TITLE
Use fs::path instead of std::filesystem::path

### DIFF
--- a/src/sqlitedb/database.hpp
+++ b/src/sqlitedb/database.hpp
@@ -9,12 +9,13 @@
 #include <chrono>
 #include <cstdlib>
 #include <exception>
-#include <filesystem>
 #include <string_view>
 #include <shared_mutex>
 #include <thread>
 #include <unordered_set>
 #include <optional>
+
+#include "common/fs.h"
 
 namespace db
 {
@@ -284,8 +285,8 @@ namespace db
       return exec_and_maybe_get<T...>(prepared_st(query), bind...);
     }
 
-    explicit Database(const std::filesystem::path& db_path, const std::string_view db_password)
-        : db{db_path, SQLite::OPEN_READWRITE | SQLite::OPEN_CREATE | SQLite::OPEN_FULLMUTEX, 5000/*ms*/}
+    explicit Database(const fs::path& db_path, const std::string_view db_password)
+        : db{db_path.u8path(), SQLite::OPEN_READWRITE | SQLite::OPEN_CREATE | SQLite::OPEN_FULLMUTEX, 5000/*ms*/}
     {
       // Don't fail on these because we can still work even if they fail
       if (int rc = db.tryExec("PRAGMA journal_mode = WAL"); rc != SQLITE_OK)


### PR DESCRIPTION
This uses the ghc filesystem backport when targetting older mac, and std::filesystem everywhere else.