### PR TITLE
Batching now accumulates a small reward for all nodes every block

### DIFF
--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -93,8 +93,9 @@ CREATE TRIGGER batch_payments_prune_paid
 AFTER UPDATE ON batch_db_info
 FOR EACH ROW
 BEGIN
-    UPDATE batched_payments_paid SET amount = 0 WHERE height_paid < (NEW.height - 10000);
+    UPDATE batch_db_info SET fire_trigger = 0;
     DELETE FROM batched_payments_paid WHERE height_paid < (NEW.height - 10000);
+    UPDATE batch_db_info SET fire_trigger = 1;
 END;
 
 CREATE TRIGGER batch_payments_delete_empty
@@ -111,7 +112,7 @@ BEGIN
 END;
 
 CREATE TRIGGER delete_payment AFTER DELETE ON batched_payments_paid
-FOR EACH ROW WHEN OLD.amount > 0 AND (SELECT fire_trigger from batch_db_info)
+FOR EACH ROW WHEN (SELECT fire_trigger from batch_db_info)
 BEGIN
     UPDATE batched_payments_accrued SET amount = (amount + OLD.amount) WHERE address = OLD.address;
 END;

--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -314,7 +314,7 @@ bool BlockchainSQLite::add_block(const cryptonote::block& block, const service_n
   bool success = false;
   try
   {
-    SQLite::Transaction transaction{db};
+    SQLite::Transaction transaction{db, SQLite::TransactionBehavior::IMMEDIATE};
 
     // Goes through the miner transactions vouts checks they are right and marks them as paid in the database
     if (!validate_batch_payment(miner_tx_vouts, *calculated_rewards, block_height, true)) {
@@ -401,7 +401,7 @@ bool BlockchainSQLite::pop_block(const cryptonote::block& block, const service_n
   bool success = false;
   try
   {
-    SQLite::Transaction transaction{db};
+    SQLite::Transaction transaction{db, SQLite::TransactionBehavior::IMMEDIATE};
 
     // Add back to the database payments that had been made in this block
     delete_block_payments(block_height);
@@ -590,7 +590,7 @@ BlockchainSQLiteTest::BlockchainSQLiteTest(BlockchainSQLiteTest &other)
   while (st2.executeStep())
     all_payments_paid.emplace_back(st2.getColumn(0).getString(), st2.getColumn(1).getInt64(), st2.getColumn(2).getInt64());
 
-  SQLite::Transaction transaction{db};
+  SQLite::Transaction transaction{db, SQLite::TransactionBehavior::IMMEDIATE};
 
   SQLite::Statement insert_payment_paid{db,
     "INSERT INTO batched_payments_paid (address, amount, height_paid) VALUES (?, ?, ?)"};

--- a/src/blockchain_db/sqlite/db_sqlite.h
+++ b/src/blockchain_db/sqlite/db_sqlite.h
@@ -61,6 +61,7 @@ public:
 
   // add_sn_payments -> passing an array of addresses and amounts. These will be added or subtracted to the database for each address specified. If the address does not exist it will be created.
   bool add_sn_payments(std::vector<cryptonote::batch_sn_payment>& payments, uint64_t block_height);
+  bool subtract_sn_payments(std::vector<cryptonote::batch_sn_payment>& payments);
 
   // get_payments -> passing a block height will return an array of payments that should be created in a coinbase transaction on that block given the current batching DB state.
   std::optional<std::vector<cryptonote::batch_sn_payment>> get_sn_payments(uint64_t block_height);
@@ -75,7 +76,7 @@ public:
   // This is the primary entry point for the blockchain to add to the batching database.
   // Each accepted block should call this passing in the SN list structure.
   bool add_block(const cryptonote::block& block, const service_nodes::service_node_list::state_t& service_nodes_state);
-  bool pop_block(const cryptonote::block& block);
+  bool pop_block(const cryptonote::block& block, const service_nodes::service_node_list::state_t& service_nodes_state);
 
   // validate_batch_payment -> used to make sure that list of miner_tx_vouts is correct. Compares the miner_tx_vouts with a list previously extracted payments to make sure that the correct persons are being paid.
   bool validate_batch_payment(std::vector<std::tuple<crypto::public_key, uint64_t>> miner_tx_vouts, std::vector<cryptonote::batch_sn_payment> calculated_payments_from_batching_db, uint64_t block_height, bool save_payment);

--- a/src/blockchain_db/sqlite/db_sqlite.h
+++ b/src/blockchain_db/sqlite/db_sqlite.h
@@ -66,11 +66,16 @@ public:
   std::optional<std::vector<cryptonote::batch_sn_payment>> get_sn_payments(uint64_t block_height);
 
   // calculate_rewards -> takes a list of contributors with their SN contribution amounts and will calculate how much of the block rewards should be the allocated to the contributors. The function will return a list suitable for passing to add_sn_payments
-  std::vector<cryptonote::batch_sn_payment> calculate_rewards(const cryptonote::block& block, std::vector<cryptonote::batch_sn_payment> contributors);
+  std::vector<cryptonote::batch_sn_payment> calculate_rewards(uint8_t hf_version, uint64_t distribution_amount, service_nodes::service_node_info sn_info);
 
-  // add/pop_block -> takes a block that contains new block rewards to be batched and added to the database and/or batching payments that need to be subtracted from the database, in addition it takes an externally generated list of contributors for the SN winner of that block. The function will then process this block add and subtracting to the batching DB appropriately. This is the primary entry point for the blockchain to add to the batching database. Each accepted block should call this passing in the SN winners contributors at the same time.
-  bool add_block(const cryptonote::block &block, std::vector<cryptonote::batch_sn_payment> contributors);
-  bool pop_block(const cryptonote::block &block, std::vector<cryptonote::batch_sn_payment> contributors);
+  // add/pop_block -> takes a block that contains new block rewards to be batched and added to the database
+  // and/or batching payments that need to be subtracted from the database, in addition it takes a reference to
+  // the service node list which it will use to calculate the individual payouts.
+  // The function will then process this block add and subtracting to the batching DB appropriately.
+  // This is the primary entry point for the blockchain to add to the batching database.
+  // Each accepted block should call this passing in the SN list structure.
+  bool add_block(const cryptonote::block& block, const service_nodes::service_node_list::state_t& service_nodes_state);
+  bool pop_block(const cryptonote::block& block);
 
   // validate_batch_payment -> used to make sure that list of miner_tx_vouts is correct. Compares the miner_tx_vouts with a list previously extracted payments to make sure that the correct persons are being paid.
   bool validate_batch_payment(std::vector<std::tuple<crypto::public_key, uint64_t>> miner_tx_vouts, std::vector<cryptonote::batch_sn_payment> calculated_payments_from_batching_db, uint64_t block_height, bool save_payment);

--- a/src/blockchain_db/sqlite/db_sqlite.h
+++ b/src/blockchain_db/sqlite/db_sqlite.h
@@ -59,19 +59,19 @@ public:
   bool decrement_height();
 
 
-  // add_sn_payments -> passing an array of addresses and amounts. These will be added or subtracted to the database for each address specified. If the address does not exist it will be created.
-  bool add_sn_payments(std::vector<cryptonote::batch_sn_payment>& payments, uint64_t block_height);
+  // add_sn_payments/subtract_sn_payments -> passing an array of addresses and amounts. These will be added or subtracted to the database for each address specified. If the address does not exist it will be created.
+  bool add_sn_payments(std::vector<cryptonote::batch_sn_payment>& payments);
   bool subtract_sn_payments(std::vector<cryptonote::batch_sn_payment>& payments);
 
   // get_payments -> passing a block height will return an array of payments that should be created in a coinbase transaction on that block given the current batching DB state.
   std::optional<std::vector<cryptonote::batch_sn_payment>> get_sn_payments(uint64_t block_height);
 
-  // calculate_rewards -> takes a list of contributors with their SN contribution amounts and will calculate how much of the block rewards should be the allocated to the contributors. The function will return a list suitable for passing to add_sn_payments
+  // calculate_rewards -> takes the list of contributors from sn_info with their SN contribution amounts and will calculate how much of the block rewards should be the allocated to the contributors. The function will return a list suitable for passing to add_sn_payments
   std::vector<cryptonote::batch_sn_payment> calculate_rewards(uint8_t hf_version, uint64_t distribution_amount, service_nodes::service_node_info sn_info);
 
   // add/pop_block -> takes a block that contains new block rewards to be batched and added to the database
   // and/or batching payments that need to be subtracted from the database, in addition it takes a reference to
-  // the service node list which it will use to calculate the individual payouts.
+  // the service node state which it will use to calculate the individual payouts.
   // The function will then process this block add and subtracting to the batching DB appropriately.
   // This is the primary entry point for the blockchain to add to the batching database.
   // Each accepted block should call this passing in the SN list structure.
@@ -82,8 +82,7 @@ public:
   bool validate_batch_payment(std::vector<std::tuple<crypto::public_key, uint64_t>> miner_tx_vouts, std::vector<cryptonote::batch_sn_payment> calculated_payments_from_batching_db, uint64_t block_height, bool save_payment);
   
   // these keep track of payments made to SN operators after then payment has been made. Allows for popping blocks back and knowing who got paid in those blocks.
-  // passing in a list of people to be marked as paid in the paid_amounts vector, the amounts MUST reconcile with what is currently in the database 
-  // else it will fail. Block height will be added to the batched_payments database as height_paid.
+  // passing in a list of people to be marked as paid in the paid_amounts vector. Block height will be added to the batched_payments_paid database as height_paid.
   bool save_payments(uint64_t block_height, std::vector<batch_sn_payment> paid_amounts);
   std::vector<cryptonote::batch_sn_payment> get_block_payments(uint64_t block_height);
   bool delete_block_payments(uint64_t block_height);

--- a/src/blockchain_db/sqlite/db_sqlite.h
+++ b/src/blockchain_db/sqlite/db_sqlite.h
@@ -79,7 +79,7 @@ public:
   bool pop_block(const cryptonote::block& block, const service_nodes::service_node_list::state_t& service_nodes_state);
 
   // validate_batch_payment -> used to make sure that list of miner_tx_vouts is correct. Compares the miner_tx_vouts with a list previously extracted payments to make sure that the correct persons are being paid.
-  bool validate_batch_payment(std::vector<std::tuple<crypto::public_key, uint64_t>> miner_tx_vouts, std::vector<cryptonote::batch_sn_payment> calculated_payments_from_batching_db, uint64_t block_height, bool save_payment);
+  bool validate_batch_payment(std::vector<std::tuple<crypto::public_key, uint64_t>> miner_tx_vouts, std::vector<cryptonote::batch_sn_payment> calculated_payments_from_batching_db, uint64_t block_height);
   
   // these keep track of payments made to SN operators after then payment has been made. Allows for popping blocks back and knowing who got paid in those blocks.
   // passing in a list of people to be marked as paid in the paid_amounts vector. Block height will be added to the batched_payments_paid database as height_paid.

--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -454,7 +454,7 @@ namespace cryptonote
       {
         VARINT_FIELD(height)
         FIELD(service_node_winner_key)
-        VARINT_FIELD(reward) 
+        FIELD(reward) 
       }
     END_SERIALIZE()
   };
@@ -488,6 +488,10 @@ namespace cryptonote
     {
       return !(*this == rhs);
     }
+
+    uint64_t modulus(uint64_t interval) const;
+    uint64_t next_payout_height(uint64_t current_height, uint64_t interval) const;
+
   };
   inline constexpr account_public_address null_address{};
 

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -258,7 +258,8 @@ namespace config
   inline constexpr std::string_view HASH_KEY_CLSAG_AGG_1 = "CLSAG_agg_1"sv;
 
   //Batching SN Rewards
-  inline constexpr uint64_t BATCHING_INTERVAL = 2000;
+  //inline constexpr uint64_t BATCHING_INTERVAL = 2000;
+  inline constexpr uint64_t BATCHING_INTERVAL = 20;
   inline constexpr uint64_t MIN_BATCH_PAYMENT_AMOUNT = 10;
   inline constexpr uint64_t LIMIT_BATCH_OUTPUTS = 15;
 

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -539,7 +539,7 @@ bool Blockchain::init(BlockchainDB* db, sqlite3 *ons_db, std::shared_ptr<crypton
       try
       {
         m_db->pop_block(popped_block, popped_txs);
-        if (!m_sqlite_db->pop_block(popped_block))
+        if (!m_service_node_list.pop_batching_rewards_block(popped_block))
         {
           LOG_ERROR("Failed to pop to batch rewards DB. throwing");
           throw;
@@ -743,7 +743,7 @@ block Blockchain::pop_block_from_blockchain()
     LOG_ERROR("Error popping block from blockchain, throwing!");
     throw;
   }
-  if (!m_sqlite_db->pop_block(popped_block))
+  if (!m_service_node_list.pop_batching_rewards_block(popped_block))
   {
     LOG_ERROR("Failed to pop to batch rewards DB. throwing");
     throw;

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -4500,6 +4500,8 @@ bool Blockchain::handle_block_to_main_chain(const block& bl, const crypto::hash&
     bvc.m_verifivation_failed = true;
     return false;
   } 
+
+  // TODO sean - this should not be here. Mock and enfore m_sqlite_db
   if (m_sqlite_db) {
     if (!m_service_node_list.process_batching_rewards(bl))
     {

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -133,7 +133,7 @@ namespace cryptonote
     return correct_key == output_key;
   }
 
-  uint64_t governance_reward_formula(uint64_t base_reward, uint8_t hf_version)
+  uint64_t governance_reward_formula(uint8_t hf_version, uint64_t base_reward)
   {
     return hf_version >= network_version_17         ? FOUNDATION_REWARD_HF17 :
            hf_version >= network_version_16_pulse   ? FOUNDATION_REWARD_HF15 + CHAINFLIP_LIQUIDITY_HF16 :
@@ -167,7 +167,7 @@ namespace cryptonote
   uint64_t derive_governance_from_block_reward(network_type nettype, const cryptonote::block &block, uint8_t hf_version)
   {
     if (hf_version >= 15)
-      return governance_reward_formula(0, hf_version);
+      return governance_reward_formula(hf_version);
 
     uint64_t result       = 0;
     uint64_t snode_reward = 0;
@@ -183,7 +183,7 @@ namespace cryptonote
     }
 
     uint64_t base_reward  = snode_reward * 2; // pre-HF15, SN reward = half of base reward
-    uint64_t governance   = governance_reward_formula(base_reward, hf_version);
+    uint64_t governance   = governance_reward_formula(hf_version, base_reward);
     uint64_t block_reward = base_reward - governance;
 
     uint64_t actual_reward = 0; // sanity check
@@ -542,7 +542,7 @@ namespace cryptonote
     // There is a goverance fee due every block.  Beginning in hardfork 10 this is still subtracted
     // from the block reward as if it was paid, but the actual payments get batched into rare, large
     // accumulated payments.  (Before hardfork 10 they are included in every block, unbatched).
-    result.governance_due  = governance_reward_formula(result.original_base_reward, hard_fork_version);
+    result.governance_due  = governance_reward_formula(hard_fork_version, result.original_base_reward);
     result.governance_paid = hard_fork_version >= network_version_10_bulletproofs
         ? oxen_context.batched_governance
         : result.governance_due;

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -295,30 +295,23 @@ namespace cryptonote
       return std::make_pair(false, block_rewards);
     }
 
-    // TODO(doyle): Batching awards
+    // NOTE: Batched Pulse Block Payment Details
     //
-    // NOTE: Summarise rewards to payout (up to 9 payout entries/outputs)
+    // Each block accrues a small reward to each service node this amount
+    // is essentially 16.5 (Coinbase reward for Service Nodes) divided by
+    // the size of the service node list. 
     //
-    // Miner Block
-    // - 1       | Miner
-    // - Up To 4 | Block Leader (Queued node at the top of the Service Node List)
-    // - Up To 1 | Governance
-    //
-    // Pulse Block
-    // - Up to 4 | Block Producer (0-3 for Pooled Service Node)
-    // - Up To 4 | Block Leader   (Queued node at the top of the Service Node List)
-    // - Up To 1 | Governance     (When a block is at the Governance payout interval)
-    //
-    // NOTE: Pulse Block Payment Details
-    //
+    // The service node list is adjusted to only accrue for nodes 
+    // that have been online for greater than 1 hour.
+    // 
     // By default, when Pulse round is 0, the Block Producer is the Block
-    // Leader. Coinbase and transaction fees are given to the Block Leader.
-    // This is the common case, and in that instance we avoid generating
-    // duplicate outputs and payment occurs in 1 output.
+    // Leader. Transaction fees are given to the Block Leader.
+    // This is the common case, and the transaction fees incentivise the 
+    // block producer to produce the block and not stall the network.
     //
     // On alternative rounds, transaction fees are given to the alternative
     // block producer (which is now different from the Block Leader). The
-    // original block producer still receives the coinbase reward. A Pulse
+    // original block producer still accrues their share of the coinbase. A Pulse
     // round's failure is determined by the non-participation of the members of
     // the quorum, so failing a round's onus is not always on the original block
     // producer (it could be the validators colluding) hence why they still

--- a/src/cryptonote_core/cryptonote_tx_utils.h
+++ b/src/cryptonote_core/cryptonote_tx_utils.h
@@ -43,7 +43,7 @@ namespace cryptonote
   bool     get_deterministic_output_key         (const account_public_address& address, const keypair& tx_key, size_t output_index, crypto::public_key& output_key);
   bool     validate_governance_reward_key       (uint64_t height, std::string_view governance_wallet_address_str, size_t output_index, const crypto::public_key& output_key, const cryptonote::network_type nettype);
 
-  uint64_t governance_reward_formula            (uint64_t base_reward, uint8_t hf_version);
+  uint64_t governance_reward_formula            (uint8_t hf_version, uint64_t base_reward = 0);
   bool     block_has_governance_output          (network_type nettype, cryptonote::block const &block);
   bool     height_has_governance_output         (network_type nettype, uint8_t hard_fork_version, uint64_t height);
   uint64_t derive_governance_from_block_reward  (network_type nettype, const cryptonote::block &block, uint8_t hf_version);

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1633,6 +1633,10 @@ namespace service_nodes
   {
     return m_blockchain.sqlite_db()->add_block(block, m_state);
   }
+  bool service_node_list::pop_batching_rewards_block(const cryptonote::block& block)
+  {
+    return m_blockchain.sqlite_db()->pop_block(block, m_state);
+  }
 
   static std::mt19937_64 quorum_rng(uint8_t hf_version, crypto::hash const &hash, quorum_type type)
   {

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -133,6 +133,10 @@ namespace service_nodes
     return sort_and_filter(service_nodes_infos, [](const service_node_info &info) { return info.is_decommissioned() && info.is_fully_funded(); }, /*reserve=*/ false);
   }
 
+  std::vector<pubkey_and_sninfo> service_node_list::state_t::payable_service_nodes_infos(uint64_t height) const {
+    return sort_and_filter(service_nodes_infos, [height](const service_node_info &info) { return info.is_payable(height); }, /*reserve=*/ true);
+  }
+
   std::shared_ptr<const quorum> service_node_list::get_quorum(quorum_type type, uint64_t height, bool include_old, std::vector<std::shared_ptr<const quorum>> *alt_quorums) const
   {
     height = offset_testing_quorum_height(type, height);
@@ -1623,6 +1627,11 @@ namespace service_nodes
       }
     }
     return result;
+  }
+
+  bool service_node_list::process_batching_rewards(const cryptonote::block& block)
+  {
+    return m_blockchain.sqlite_db()->add_block(block, m_state);
   }
 
   static std::mt19937_64 quorum_rng(uint8_t hf_version, crypto::hash const &hash, quorum_type type)

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -456,6 +456,7 @@ namespace service_nodes
 
     bool block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs, cryptonote::checkpoint_t const *checkpoint) override;
     bool process_batching_rewards(const cryptonote::block& block);
+    bool pop_batching_rewards_block(const cryptonote::block& block);
     void blockchain_detached(uint64_t height, bool by_pop_blocks) override;
     void init() override;
     bool validate_miner_tx(cryptonote::block const &block, cryptonote::block_reward_parts const &base_reward, std::optional<std::vector<cryptonote::batch_sn_payment>> const &batched_sn_payments) const override;

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -240,6 +240,11 @@ namespace service_nodes {
   //If the below percentage of service nodes are out of sync we will consider our clock out of sync
   constexpr uint8_t MAXIMUM_EXTERNAL_OUT_OF_SYNC = 80;
 
+  // If a node has been online for this amount of blocks they will receive SN rewards
+  //constexpr uint64_t SERVICE_NODE_PAYABLE_AFTER_BLOCKS = 720;
+  // TODO(sean): this should be made an actual number
+  constexpr uint64_t SERVICE_NODE_PAYABLE_AFTER_BLOCKS = 4;
+
 static_assert(STAKING_PORTIONS != UINT64_MAX, "UINT64_MAX is used as the invalid value for failing to calculate the min_node_contribution");
 // return: UINT64_MAX if (num_contributions > the max number of contributions), otherwise the amount in oxen atomic units
 uint64_t get_min_node_contribution            (uint8_t version, uint64_t staking_requirement, uint64_t total_reserved, size_t num_contributions);

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1831,19 +1831,19 @@ namespace cryptonote { namespace rpc {
     response.difficulty = m_core.get_blockchain_storage().block_difficulty(height);
     response.cumulative_difficulty = m_core.get_blockchain_storage().get_db().get_block_cumulative_difficulty(height);
     response.block_weight = m_core.get_blockchain_storage().get_db().get_block_weight(height);
-    response.reward = get_block_reward(blk);
+    response.reward = (blk.reward > 0) ? blk.reward : get_block_reward(blk);
     response.block_size = response.block_weight = m_core.get_blockchain_storage().get_db().get_block_weight(height);
     response.num_txes = blk.tx_hashes.size();
     if (fill_pow_hash)
       response.pow_hash = tools::type_to_hex(get_block_longhash_w_blockchain(m_core.get_nettype(), &(m_core.get_blockchain_storage()), blk, height, 0));
     response.long_term_weight = m_core.get_blockchain_storage().get_db().get_block_long_term_weight(height);
+    response.service_node_winner = (tools::type_to_hex(blk.service_node_winner_key) == "") ? tools::type_to_hex(cryptonote::get_service_node_winner_from_tx_extra(blk.miner_tx.extra)) : tools::type_to_hex(blk.service_node_winner_key);
     if (blk.miner_tx.vout.size() > 0)
     {
       response.miner_reward = blk.miner_tx.vout[0].amount;
       response.miner_tx_hash = tools::type_to_hex(cryptonote::get_transaction_hash(blk.miner_tx));
-      response.service_node_winner = tools::type_to_hex(cryptonote::get_service_node_winner_from_tx_extra(blk.miner_tx.extra));
     } else {
-      response.miner_reward = blk.reward;
+      response.miner_reward = get_block_reward(blk);
     }
     if (get_tx_hashes)
     {

--- a/src/sqlitedb/database.hpp
+++ b/src/sqlitedb/database.hpp
@@ -286,7 +286,7 @@ namespace db
     }
 
     explicit Database(const fs::path& db_path, const std::string_view db_password)
-        : db{db_path.u8path(), SQLite::OPEN_READWRITE | SQLite::OPEN_CREATE | SQLite::OPEN_FULLMUTEX, 5000/*ms*/}
+        : db{db_path.u8string(), SQLite::OPEN_READWRITE | SQLite::OPEN_CREATE | SQLite::OPEN_FULLMUTEX, 5000/*ms*/}
     {
       // Don't fail on these because we can still work even if they fail
       if (int rc = db.tryExec("PRAGMA journal_mode = WAL"); rc != SQLITE_OK)

--- a/src/sqlitedb/database.hpp
+++ b/src/sqlitedb/database.hpp
@@ -9,12 +9,13 @@
 #include <chrono>
 #include <cstdlib>
 #include <exception>
-#include <filesystem>
 #include <string_view>
 #include <shared_mutex>
 #include <thread>
 #include <unordered_set>
 #include <optional>
+
+#include "common/fs.h"
 
 namespace db
 {
@@ -284,8 +285,8 @@ namespace db
       return exec_and_maybe_get<T...>(prepared_st(query), bind...);
     }
 
-    explicit Database(const std::filesystem::path& db_path, const std::string_view db_password)
-        : db{db_path, SQLite::OPEN_READWRITE | SQLite::OPEN_CREATE | SQLite::OPEN_FULLMUTEX, 5000/*ms*/}
+    explicit Database(const fs::path& db_path, const std::string_view db_password)
+        : db{db_path.u8path(), SQLite::OPEN_READWRITE | SQLite::OPEN_CREATE | SQLite::OPEN_FULLMUTEX, 5000/*ms*/}
     {
       // Don't fail on these because we can still work even if they fail
       if (int rc = db.tryExec("PRAGMA journal_mode = WAL"); rc != SQLITE_OK)

--- a/tests/core_tests/block_validation.cpp
+++ b/tests/core_tests/block_validation.cpp
@@ -448,7 +448,7 @@ static bool construct_miner_tx_with_extra_output(cryptonote::transaction& tx,
 
     uint64_t governance_reward = 0;
     if (already_generated_coins != 0) {
-        governance_reward = governance_reward_formula(block_reward, hard_fork_version);
+        governance_reward = governance_reward_formula(hard_fork_version, block_reward);
         block_reward -= governance_reward;
     }
 

--- a/tests/core_tests/chaingen.cpp
+++ b/tests/core_tests/chaingen.cpp
@@ -1272,7 +1272,7 @@ static void manual_calc_batched_governance(const test_generator &generator,
 
     if (hard_fork_version >= cryptonote::network_version_15_ons)
     {
-      miner_tx_context.batched_governance = num_blocks * cryptonote::governance_reward_formula(0, hard_fork_version);
+      miner_tx_context.batched_governance = num_blocks * cryptonote::governance_reward_formula(hard_fork_version);
       return;
     }
 

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -1445,7 +1445,7 @@ struct oxen_chain_generator
   const std::vector<cryptonote::hard_fork>                           hard_forks_;
   cryptonote::account_base                                           first_miner_;
 
-  oxen_chain_generator(std::vector<test_event_entry> &events, const std::vector<cryptonote::hard_fork>& hard_forks);
+  oxen_chain_generator(std::vector<test_event_entry>& events, const std::vector<cryptonote::hard_fork>& hard_forks, std::string first_miner_seed = "");
   oxen_chain_generator(const oxen_chain_generator &other)
     :tx_table_(other.tx_table_), service_node_keys_(other.service_node_keys_), state_history_(other.state_history_), last_cull_height_(other.last_cull_height_), sqlite_db_(std::make_unique<cryptonote::BlockchainSQLiteTest>(*other.sqlite_db_)),
   ons_db_(other.ons_db_ ), db_(other.db_), hf_version_(other.hf_version_), events_(other.events_), hard_forks_(other.hard_forks_), first_miner_(other.first_miner_) {};

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -1386,6 +1386,7 @@ struct oxen_blockchain_entry
   cryptonote::checkpoint_t                   checkpoint;
 };
 
+
 struct oxen_chain_generator_db : public cryptonote::BaseTestDB
 {
   std::vector<oxen_blockchain_entry>                        blocks;
@@ -1434,7 +1435,6 @@ struct oxen_chain_generator
   // We already store blockchain_entries in block_ vector which stores the actual backing transaction entries.
   std::unordered_map<crypto::hash, cryptonote::transaction>          tx_table_;
   mutable std::unordered_map<crypto::public_key, crypto::secret_key> service_node_keys_;
-  std::unordered_map<crypto::public_key, std::vector<std::pair<cryptonote::account_public_address, uint64_t>>> service_node_contributors_;
   service_nodes::service_node_list::state_set                        state_history_;
   uint64_t                                                           last_cull_height_ = 0;
   std::shared_ptr<ons::name_system_db>                               ons_db_ = std::make_shared<ons::name_system_db>();
@@ -1447,7 +1447,7 @@ struct oxen_chain_generator
 
   oxen_chain_generator(std::vector<test_event_entry> &events, const std::vector<cryptonote::hard_fork>& hard_forks);
   oxen_chain_generator(const oxen_chain_generator &other)
-    :tx_table_(other.tx_table_), service_node_keys_(other.service_node_keys_), service_node_contributors_(other.service_node_contributors_), state_history_(other.state_history_), last_cull_height_(other.last_cull_height_), sqlite_db_(std::make_unique<cryptonote::BlockchainSQLiteTest>(*other.sqlite_db_)),
+    :tx_table_(other.tx_table_), service_node_keys_(other.service_node_keys_), state_history_(other.state_history_), last_cull_height_(other.last_cull_height_), sqlite_db_(std::make_unique<cryptonote::BlockchainSQLiteTest>(*other.sqlite_db_)),
   ons_db_(other.ons_db_ ), db_(other.db_), hf_version_(other.hf_version_), events_(other.events_), hard_forks_(other.hard_forks_), first_miner_(other.first_miner_) {};
 
   uint64_t                                             height()       const { return cryptonote::get_block_height(db_.blocks.back().block); }

--- a/tests/core_tests/chaingen_main.cpp
+++ b/tests/core_tests/chaingen_main.cpp
@@ -151,6 +151,7 @@ int main(int argc, char* argv[])
     GENERATE_AND_PLAY(oxen_batch_sn_rewards_bad_amount);
     GENERATE_AND_PLAY(oxen_batch_sn_rewards_bad_address);
     GENERATE_AND_PLAY(oxen_batch_sn_rewards_pop_blocks);
+    GENERATE_AND_PLAY(oxen_batch_sn_rewards_pop_blocks_after_big_cycle);
 
     // NOTE: Monero Tests
     GENERATE_AND_PLAY(gen_simple_chain_001);

--- a/tests/core_tests/oxen_tests.cpp
+++ b/tests/core_tests/oxen_tests.cpp
@@ -3599,11 +3599,16 @@ bool oxen_batch_sn_rewards_pop_blocks::generate(std::vector<test_event_entry> &e
 
     records = (*sqliteDB).get_sn_payments(curr_height);
     CHECK_EQ(records.has_value(), true);
-    CHECK_EQ((*records).size(), 1);
-    // Check that the database has a lower amount that does not include the popped block
-    batched_rewards_earned = MK_COINS(1) * 16.5 * (more_blocks - service_nodes::SERVICE_NODE_PAYABLE_AFTER_BLOCKS - 1);
-    CHECK_EQ((*records)[0].amount, batched_rewards_earned);
-    CHECK_EQ(tools::view_guts((*records)[0].address_info.address), tools::view_guts(alice.get_keys().m_account_address));
+    if (batched_rewards_earned != MK_COINS(1) * 16.5)
+    {
+      CHECK_EQ((*records).size(), 1);
+      // Check that the database has a lower amount that does not include the popped block
+      batched_rewards_earned = MK_COINS(1) * 16.5 * (more_blocks - service_nodes::SERVICE_NODE_PAYABLE_AFTER_BLOCKS - 1);
+      CHECK_EQ((*records)[0].amount, batched_rewards_earned);
+      CHECK_EQ(tools::view_guts((*records)[0].address_info.address), tools::view_guts(alice.get_keys().m_account_address));
+    }
+    else
+      CHECK_EQ((*records).size(), 0);
 
     // Pop the rest of the blocks and check that it goes to zero
     blockchain.pop_blocks(more_blocks - 1);

--- a/tests/core_tests/oxen_tests.cpp
+++ b/tests/core_tests/oxen_tests.cpp
@@ -95,17 +95,17 @@ bool oxen_checkpointing_alt_chain_handle_alt_blocks_at_tip::generate(std::vector
 
   crypto::hash curr_hash = get_block_hash(gen.top().block);
   oxen_register_callback(events, "check_alt_block_count", [curr_height, curr_hash](cryptonote::core &c, size_t ev_index)
-  {
-    DEFINE_TESTS_ERROR_CONTEXT("check_alt_block_count");
+      {
+      DEFINE_TESTS_ERROR_CONTEXT("check_alt_block_count");
 
-    uint64_t top_height;
-    crypto::hash top_hash;
-    c.get_blockchain_top(top_height, top_hash);
-    CHECK_EQ(top_height, curr_height);
-    CHECK_EQ(top_hash, curr_hash);
-    CHECK_TEST_CONDITION(c.get_blockchain_storage().get_alternative_blocks_count() > 0);
-    return true;
-  });
+      uint64_t top_height;
+      crypto::hash top_hash;
+      c.get_blockchain_top(top_height, top_hash);
+      CHECK_EQ(top_height, curr_height);
+      CHECK_EQ(top_hash, curr_hash);
+      CHECK_TEST_CONDITION(c.get_blockchain_storage().get_alternative_blocks_count() > 0);
+      return true;
+      });
 
   // NOTE: We add a new block ontop that causes the alt block code path to run
   // again, and calculate that this alt chain now has 2 blocks on it with
@@ -119,15 +119,15 @@ bool oxen_checkpointing_alt_chain_handle_alt_blocks_at_tip::generate(std::vector
 
   crypto::hash expected_top_hash = cryptonote::get_block_hash(fork.top().block); 
   oxen_register_callback(events, "check_chain_reorged", [expected_top_hash](cryptonote::core &c, size_t ev_index)
-  {
-    DEFINE_TESTS_ERROR_CONTEXT("check_chain_reorged");
-    CHECK_EQ(c.get_blockchain_storage().get_alternative_blocks_count(), 0);
-    uint64_t top_height;
-    crypto::hash top_hash;
-    c.get_blockchain_top(top_height, top_hash);
-    CHECK_EQ(expected_top_hash, top_hash);
-    return true;
-  });
+      {
+      DEFINE_TESTS_ERROR_CONTEXT("check_chain_reorged");
+      CHECK_EQ(c.get_blockchain_storage().get_alternative_blocks_count(), 0);
+      uint64_t top_height;
+      crypto::hash top_hash;
+      c.get_blockchain_top(top_height, top_hash);
+      CHECK_EQ(expected_top_hash, top_hash);
+      return true;
+      });
   return true;
 }
 
@@ -152,15 +152,15 @@ bool oxen_checkpointing_alt_chain_more_service_node_checkpoints_less_pow_overtak
   crypto::hash const fork_top_hash = cryptonote::get_block_hash(fork_with_more_checkpoints.top().block);
 
   oxen_register_callback(events, "check_switched_to_alt_chain", [fork_top_hash, fork_top_height](cryptonote::core &c, size_t ev_index)
-  {
-    DEFINE_TESTS_ERROR_CONTEXT("check_switched_to_alt_chain");
-    uint64_t top_height;
-    crypto::hash top_hash;
-    c.get_blockchain_top(top_height, top_hash);
-    CHECK_EQ(top_height, fork_top_height);
-    CHECK_EQ(top_hash, fork_top_hash);
-    return true;
-  });
+      {
+      DEFINE_TESTS_ERROR_CONTEXT("check_switched_to_alt_chain");
+      uint64_t top_height;
+      crypto::hash top_hash;
+      c.get_blockchain_top(top_height, top_hash);
+      CHECK_EQ(top_height, fork_top_height);
+      CHECK_EQ(top_hash, fork_top_hash);
+      return true;
+      });
   return true;
 }
 
@@ -217,14 +217,14 @@ bool oxen_checkpointing_alt_chain_receive_checkpoint_votes_should_reorg_back::ge
   fork.create_and_add_next_block({});
   crypto::hash const fork_top_hash = cryptonote::get_block_hash(fork.top().block);
   oxen_register_callback(events, "check_switched_to_alt_chain", [fork_top_hash](cryptonote::core &c, size_t ev_index)
-  {
-    DEFINE_TESTS_ERROR_CONTEXT("check_switched_to_alt_chain");
-    uint64_t top_height;
-    crypto::hash top_hash;
-    c.get_blockchain_top(top_height, top_hash);
-    CHECK_EQ(fork_top_hash, top_hash);
-    return true;
-  });
+      {
+      DEFINE_TESTS_ERROR_CONTEXT("check_switched_to_alt_chain");
+      uint64_t top_height;
+      crypto::hash top_hash;
+      c.get_blockchain_top(top_height, top_hash);
+      CHECK_EQ(fork_top_hash, top_hash);
+      return true;
+      });
   return true;
 }
 
@@ -285,14 +285,14 @@ bool oxen_checkpointing_alt_chain_with_increasing_service_node_checkpoints::gene
 
   crypto::hash const gen_top_hash = cryptonote::get_block_hash(gen.top().block);
   oxen_register_callback(events, "check_still_on_main_chain", [gen_top_hash](cryptonote::core &c, size_t ev_index)
-  {
-    DEFINE_TESTS_ERROR_CONTEXT("check_still_on_main_chain");
-    uint64_t top_height;
-    crypto::hash top_hash;
-    c.get_blockchain_top(top_height, top_hash);
-    CHECK_EQ(top_hash, gen_top_hash);
-    return true;
-  });
+      {
+      DEFINE_TESTS_ERROR_CONTEXT("check_still_on_main_chain");
+      uint64_t top_height;
+      crypto::hash top_hash;
+      c.get_blockchain_top(top_height, top_hash);
+      CHECK_EQ(top_hash, gen_top_hash);
+      return true;
+      });
 
   // Now create the following chain, the fork chain should be switched to due to now having more checkpoints
   // Main chain   C B B B B | B B B B B
@@ -307,14 +307,14 @@ bool oxen_checkpointing_alt_chain_with_increasing_service_node_checkpoints::gene
 
   crypto::hash const fork_top_hash = cryptonote::get_block_hash(fork.top().block);
   oxen_register_callback(events, "check_switched_to_alt_chain", [fork_top_hash](cryptonote::core &c, size_t ev_index)
-  {
-    DEFINE_TESTS_ERROR_CONTEXT("check_switched_to_alt_chain");
-    uint64_t top_height;
-    crypto::hash top_hash;
-    c.get_blockchain_top(top_height, top_hash);
-    CHECK_EQ(fork_top_hash, top_hash);
-    return true;
-  });
+      {
+      DEFINE_TESTS_ERROR_CONTEXT("check_switched_to_alt_chain");
+      uint64_t top_height;
+      crypto::hash top_hash;
+      c.get_blockchain_top(top_height, top_hash);
+      CHECK_EQ(fork_top_hash, top_hash);
+      return true;
+      });
   return true;
 }
 
@@ -350,9 +350,9 @@ bool oxen_checkpointing_service_node_checkpoint_from_votes::generate(std::vector
 
     service_nodes::quorum_vote_t invalid_vote = service_nodes::make_checkpointing_vote(gen.top().block.major_version, checkpointed_hash, checkpointed_height, 0, invalid_keys);
     gen.events_.push_back(oxen_blockchain_addable<decltype(invalid_vote)>(
-        invalid_vote,
-        false /*can_be_added_to_blockchain*/,
-        "Can not add a vote that uses a service node key not part of the quorum"));
+          invalid_vote,
+          false /*can_be_added_to_blockchain*/,
+          "Can not add a vote that uses a service node key not part of the quorum"));
   }
 
   // NOTE: Add insufficient service node votes and check that no checkpoint is generated yet
@@ -360,24 +360,24 @@ bool oxen_checkpointing_service_node_checkpoint_from_votes::generate(std::vector
     gen.events_.push_back(oxen_blockchain_addable<service_nodes::quorum_vote_t>(checkpoint_votes[i]));
 
   oxen_register_callback(events, "check_service_node_checkpoint_rejected_insufficient_votes", [checkpointed_height](cryptonote::core &c, size_t ev_index)
-  {
-    DEFINE_TESTS_ERROR_CONTEXT("check_service_node_checkpoint_rejected_insufficient_votes");
-    cryptonote::Blockchain const &blockchain = c.get_blockchain_storage();
-    cryptonote::checkpoint_t real_checkpoint;
-    CHECK_TEST_CONDITION(blockchain.get_checkpoint(checkpointed_height, real_checkpoint) == false);
-    return true;
-  });
+      {
+      DEFINE_TESTS_ERROR_CONTEXT("check_service_node_checkpoint_rejected_insufficient_votes");
+      cryptonote::Blockchain const &blockchain = c.get_blockchain_storage();
+      cryptonote::checkpoint_t real_checkpoint;
+      CHECK_TEST_CONDITION(blockchain.get_checkpoint(checkpointed_height, real_checkpoint) == false);
+      return true;
+      });
 
   // NOTE: Add last vote and check checkpoint has been generated
   gen.events_.push_back(checkpoint_votes.back());
   oxen_register_callback(events, "check_service_node_checkpoint_accepted", [checkpointed_height](cryptonote::core &c, size_t ev_index)
-  {
-    DEFINE_TESTS_ERROR_CONTEXT("check_service_node_checkpoint_accepted");
-    cryptonote::Blockchain const &blockchain = c.get_blockchain_storage();
-    cryptonote::checkpoint_t real_checkpoint;
-    CHECK_TEST_CONDITION(blockchain.get_checkpoint(checkpointed_height, real_checkpoint));
-    return true;
-  });
+      {
+      DEFINE_TESTS_ERROR_CONTEXT("check_service_node_checkpoint_accepted");
+      cryptonote::Blockchain const &blockchain = c.get_blockchain_storage();
+      cryptonote::checkpoint_t real_checkpoint;
+      CHECK_TEST_CONDITION(blockchain.get_checkpoint(checkpointed_height, real_checkpoint));
+      return true;
+      });
 
   return true;
 }
@@ -454,20 +454,20 @@ bool oxen_core_block_reward_unpenalized_pre_pulse::generate(std::vector<test_eve
   uint64_t expected_service_node_reward = cryptonote::service_node_reward_formula(unpenalized_block_reward, newest_hf);
 
   oxen_register_callback(events, "check_block_rewards", [unpenalized_block_reward, expected_service_node_reward](cryptonote::core &c, size_t ev_index)
-  {
-    DEFINE_TESTS_ERROR_CONTEXT("check_block_rewards");
-    uint64_t top_height;
-    crypto::hash top_hash;
-    c.get_blockchain_top(top_height, top_hash);
+      {
+      DEFINE_TESTS_ERROR_CONTEXT("check_block_rewards");
+      uint64_t top_height;
+      crypto::hash top_hash;
+      c.get_blockchain_top(top_height, top_hash);
 
-    bool orphan;
-    cryptonote::block top_block;
-    CHECK_TEST_CONDITION(c.get_block_by_hash(top_hash, top_block, &orphan));
-    CHECK_TEST_CONDITION(orphan == false);
-    CHECK_TEST_CONDITION_MSG(top_block.miner_tx.vout[0].amount < unpenalized_block_reward, "We should add enough transactions that the penalty is realised on the base block reward");
-    CHECK_EQ(top_block.miner_tx.vout[1].amount, expected_service_node_reward);
-    return true;
-  });
+      bool orphan;
+      cryptonote::block top_block;
+      CHECK_TEST_CONDITION(c.get_block_by_hash(top_hash, top_block, &orphan));
+      CHECK_TEST_CONDITION(orphan == false);
+      CHECK_TEST_CONDITION_MSG(top_block.miner_tx.vout[0].amount < unpenalized_block_reward, "We should add enough transactions that the penalty is realised on the base block reward");
+      CHECK_EQ(top_block.miner_tx.vout[1].amount, expected_service_node_reward);
+      return true;
+      });
   return true;
 }
 
@@ -495,28 +495,28 @@ bool oxen_core_block_reward_unpenalized_post_pulse::generate(std::vector<test_ev
 
   uint64_t unpenalized_reward = cryptonote::service_node_reward_formula(BLOCK_REWARD_HF17, newest_hf);
   oxen_register_callback(events, "check_block_rewards", [unpenalized_reward, tx_fee](cryptonote::core &c, size_t ev_index)
-  {
-    DEFINE_TESTS_ERROR_CONTEXT("check_block_rewards");
-    uint64_t top_height;
-    crypto::hash top_hash;
-    c.get_blockchain_top(top_height, top_hash);
+      {
+      DEFINE_TESTS_ERROR_CONTEXT("check_block_rewards");
+      uint64_t top_height;
+      crypto::hash top_hash;
+      c.get_blockchain_top(top_height, top_hash);
 
-    bool orphan;
-    cryptonote::block top_block;
-    CHECK_TEST_CONDITION(c.get_block_by_hash(top_hash, top_block, &orphan));
+      bool orphan;
+      cryptonote::block top_block;
+      CHECK_TEST_CONDITION(c.get_block_by_hash(top_hash, top_block, &orphan));
 
-    CHECK_TEST_CONDITION(orphan == false);
+      CHECK_TEST_CONDITION(orphan == false);
 
-    uint64_t rewards_from_fee = top_block.miner_tx.vout[0].amount;
-    CHECK_TEST_CONDITION_MSG(top_block.miner_tx.vout.size() == 2, "1 for miner, 1 for service node");
-    CHECK_TEST_CONDITION_MSG(rewards_from_fee > 0 && rewards_from_fee < tx_fee, "Block producer should receive a penalised tx fee less than " << cryptonote::print_money(tx_fee) << "received, " << cryptonote::print_money(rewards_from_fee) << "");
-    CHECK_TEST_CONDITION_MSG(top_block.miner_tx.vout[1].amount == unpenalized_reward, "Service Node should receive full reward " << unpenalized_reward);
+      uint64_t rewards_from_fee = top_block.miner_tx.vout[0].amount;
+      CHECK_TEST_CONDITION_MSG(top_block.miner_tx.vout.size() == 2, "1 for miner, 1 for service node");
+      CHECK_TEST_CONDITION_MSG(rewards_from_fee > 0 && rewards_from_fee < tx_fee, "Block producer should receive a penalised tx fee less than " << cryptonote::print_money(tx_fee) << "received, " << cryptonote::print_money(rewards_from_fee) << "");
+      CHECK_TEST_CONDITION_MSG(top_block.miner_tx.vout[1].amount == unpenalized_reward, "Service Node should receive full reward " << unpenalized_reward);
 
-    MGINFO("rewards_from_fee: "   << cryptonote::print_money(rewards_from_fee));
-    MGINFO("tx_fee: "             << cryptonote::print_money(tx_fee));
-    MGINFO("unpenalized_amount: " << cryptonote::print_money(unpenalized_reward));
-    return true;
-  });
+      MGINFO("rewards_from_fee: "   << cryptonote::print_money(rewards_from_fee));
+      MGINFO("tx_fee: "             << cryptonote::print_money(tx_fee));
+      MGINFO("unpenalized_amount: " << cryptonote::print_money(unpenalized_reward));
+      return true;
+      });
   return true;
 }
 
@@ -538,8 +538,8 @@ bool oxen_core_fee_burning::generate(std::vector<test_event_entry>& events)
 
   static constexpr std::array<std::array<uint64_t, 3>, 3> send_fee_burn{{
     {MK_COINS(5), MK_COINS(3), MK_COINS(1)},
-    {MK_COINS(10), MK_COINS(5), MK_COINS(2)},
-    {MK_COINS(5), MK_COINS(2), MK_COINS(1)},
+      {MK_COINS(10), MK_COINS(5), MK_COINS(2)},
+      {MK_COINS(5), MK_COINS(2), MK_COINS(1)},
   }};
 
   auto add_burning_tx = [&events, &gen, &dummy, newest_hf](const std::array<uint64_t, 3> &send_fee_burn) {
@@ -584,23 +584,23 @@ bool oxen_core_fee_burning::generate(std::vector<test_event_entry>& events)
   }
 
   oxen_register_callback(events, "check_fee_burned", [good_hash, good_miner_reward](cryptonote::core &c, size_t ev_index)
-  {
-    DEFINE_TESTS_ERROR_CONTEXT("check_fee_burned");
-    uint64_t top_height;
-    crypto::hash top_hash;
-    c.get_blockchain_top(top_height, top_hash);
+      {
+      DEFINE_TESTS_ERROR_CONTEXT("check_fee_burned");
+      uint64_t top_height;
+      crypto::hash top_hash;
+      c.get_blockchain_top(top_height, top_hash);
 
-    bool orphan;
-    cryptonote::block top_block;
-    CHECK_TEST_CONDITION(c.get_block_by_hash(top_hash, top_block, &orphan));
-    CHECK_TEST_CONDITION(orphan == false);
+      bool orphan;
+      cryptonote::block top_block;
+      CHECK_TEST_CONDITION(c.get_block_by_hash(top_hash, top_block, &orphan));
+      CHECK_TEST_CONDITION(orphan == false);
 
-    CHECK_EQ(top_hash, good_hash);
+      CHECK_EQ(top_hash, good_hash);
 
-    CHECK_EQ(top_block.reward, good_miner_reward);
+      CHECK_EQ(top_block.reward, good_miner_reward);
 
-    return true;
-  });
+      return true;
+      });
   return true;
 }
 
@@ -633,9 +633,9 @@ bool oxen_core_governance_batched_reward::generate(std::vector<test_event_entry>
     // you don't atleast progress and generate blocks from hf8 you will run into
     // problems
     std::vector<cryptonote::hard_fork> other_hard_forks = {
-        {7,0,0,0},
-        {8,0,1,0},
-        {9,0,hf10_height,0}};
+      {7,0,0,0},
+      {8,0,1,0},
+      {9,0,hf10_height,0}};
 
     std::vector<test_event_entry> unused_events;
     oxen_chain_generator no_batched_governance_generator(unused_events, other_hard_forks);
@@ -656,25 +656,25 @@ bool oxen_core_governance_batched_reward::generate(std::vector<test_event_entry>
   }
 
   oxen_register_callback(events, "check_batched_governance_amount_matches", [hf10_height, expected_total_governance_paid](cryptonote::core &c, size_t ev_index)
-  {
-    DEFINE_TESTS_ERROR_CONTEXT("check_batched_governance_amount_matches");
+      {
+      DEFINE_TESTS_ERROR_CONTEXT("check_batched_governance_amount_matches");
 
-    uint64_t height = c.get_current_blockchain_height();
-    std::vector<cryptonote::block> blockchain;
-    if (!c.get_blocks((uint64_t)0, (size_t)height, blockchain))
+      uint64_t height = c.get_current_blockchain_height();
+      std::vector<cryptonote::block> blockchain;
+      if (!c.get_blocks((uint64_t)0, (size_t)height, blockchain))
       return false;
 
-    uint64_t governance = 0;
-    for (size_t block_height = hf10_height; block_height < blockchain.size(); ++block_height)
-    {
+      uint64_t governance = 0;
+      for (size_t block_height = hf10_height; block_height < blockchain.size(); ++block_height)
+      {
       const cryptonote::block &block = blockchain[block_height];
       if (cryptonote::block_has_governance_output(cryptonote::FAKECHAIN, block))
-        governance += block.miner_tx.vout.back().amount;
-    }
+      governance += block.miner_tx.vout.back().amount;
+      }
 
-    CHECK_EQ(governance, expected_total_governance_paid);
-    return true;
-  });
+      CHECK_EQ(governance, expected_total_governance_paid);
+      return true;
+      });
 
   return true;
 }
@@ -701,64 +701,64 @@ bool oxen_core_block_rewards_lrc6::generate(std::vector<test_event_entry>& event
   }
 
   oxen_register_callback(events, "check_lrc6_7_block_rewards", [hf15_height, hf16_height, hf17_height, interval=network.GOVERNANCE_REWARD_INTERVAL_IN_BLOCKS](cryptonote::core &c, size_t ev_index)
-  {
-    DEFINE_TESTS_ERROR_CONTEXT("check_lrc6_7_block_rewards");
+      {
+      DEFINE_TESTS_ERROR_CONTEXT("check_lrc6_7_block_rewards");
 
-    uint64_t height = c.get_current_blockchain_height();
-    std::vector<cryptonote::block> blockchain;
-    if (!c.get_blocks((uint64_t)0, (size_t)height, blockchain))
+      uint64_t height = c.get_current_blockchain_height();
+      std::vector<cryptonote::block> blockchain;
+      if (!c.get_blocks((uint64_t)0, (size_t)height, blockchain))
       return false;
 
-    int hf15_gov = 0, hf16_gov = 0, hf17_gov = 0;
-    for (size_t block_height = hf15_height; block_height < hf16_height; ++block_height)
-    {
+      int hf15_gov = 0, hf16_gov = 0, hf17_gov = 0;
+      for (size_t block_height = hf15_height; block_height < hf16_height; ++block_height)
+      {
       const cryptonote::block &block = blockchain[block_height];
       CHECK_EQ(block.miner_tx.vout.at(0).amount, MINER_REWARD_HF15);
       CHECK_EQ(block.miner_tx.vout.at(1).amount, SN_REWARD_HF15);
       if (cryptonote::block_has_governance_output(cryptonote::FAKECHAIN, block))
       {
-        hf15_gov++;
-        CHECK_EQ(block.miner_tx.vout.at(2).amount, FOUNDATION_REWARD_HF15 * interval);
-        CHECK_EQ(block.miner_tx.vout.size(), 3);
+      hf15_gov++;
+      CHECK_EQ(block.miner_tx.vout.at(2).amount, FOUNDATION_REWARD_HF15 * interval);
+      CHECK_EQ(block.miner_tx.vout.size(), 3);
       }
       else
         CHECK_EQ(block.miner_tx.vout.size(), 2);
-    }
+      }
 
-    for (size_t block_height = hf16_height; block_height < hf17_height; ++block_height)
-    {
-      const cryptonote::block &block = blockchain[block_height];
-      CHECK_EQ(block.miner_tx.vout.at(0).amount, SN_REWARD_HF15);
-      if (cryptonote::block_has_governance_output(cryptonote::FAKECHAIN, block))
+      for (size_t block_height = hf16_height; block_height < hf17_height; ++block_height)
       {
-        hf16_gov++;
-        CHECK_EQ(block.miner_tx.vout.at(1).amount, (FOUNDATION_REWARD_HF15 + CHAINFLIP_LIQUIDITY_HF16) * interval);
-        CHECK_EQ(block.miner_tx.vout.size(), 2);
+        const cryptonote::block &block = blockchain[block_height];
+        CHECK_EQ(block.miner_tx.vout.at(0).amount, SN_REWARD_HF15);
+        if (cryptonote::block_has_governance_output(cryptonote::FAKECHAIN, block))
+        {
+          hf16_gov++;
+          CHECK_EQ(block.miner_tx.vout.at(1).amount, (FOUNDATION_REWARD_HF15 + CHAINFLIP_LIQUIDITY_HF16) * interval);
+          CHECK_EQ(block.miner_tx.vout.size(), 2);
+        }
+        else
+          CHECK_EQ(block.miner_tx.vout.size(), 1);
       }
-      else
-        CHECK_EQ(block.miner_tx.vout.size(), 1);
-    }
 
-    for (size_t block_height = hf17_height; block_height < height; ++block_height)
-    {
-      const cryptonote::block &block = blockchain[block_height];
-      CHECK_EQ(block.miner_tx.vout.at(0).amount, SN_REWARD_HF15);
-      if (cryptonote::block_has_governance_output(cryptonote::FAKECHAIN, block))
+      for (size_t block_height = hf17_height; block_height < height; ++block_height)
       {
-        hf17_gov++;
-        CHECK_EQ(block.miner_tx.vout.at(1).amount, FOUNDATION_REWARD_HF17 * interval);
-        CHECK_EQ(block.miner_tx.vout.size(), 2);
+        const cryptonote::block &block = blockchain[block_height];
+        CHECK_EQ(block.miner_tx.vout.at(0).amount, SN_REWARD_HF15);
+        if (cryptonote::block_has_governance_output(cryptonote::FAKECHAIN, block))
+        {
+          hf17_gov++;
+          CHECK_EQ(block.miner_tx.vout.at(1).amount, FOUNDATION_REWARD_HF17 * interval);
+          CHECK_EQ(block.miner_tx.vout.size(), 2);
+        }
+        else
+          CHECK_EQ(block.miner_tx.vout.size(), 1);
       }
-      else
-        CHECK_EQ(block.miner_tx.vout.size(), 1);
-    }
 
-    CHECK_EQ(hf15_gov, 1);
-    CHECK_EQ(hf16_gov, 1);
-    CHECK_EQ(hf17_gov, 1);
+      CHECK_EQ(hf15_gov, 1);
+      CHECK_EQ(hf16_gov, 1);
+      CHECK_EQ(hf17_gov, 1);
 
-    return true;
-  });
+      return true;
+      });
 
   return true;
 }
@@ -792,34 +792,34 @@ bool oxen_core_test_deregister_preferred::generate(std::vector<test_event_entry>
   gen.create_and_add_state_change_tx(service_nodes::new_state::deregister, deregister_pub_key_2, 0, 0);
 
   oxen_register_callback(events, "check_prefer_deregisters", [&events, miner](cryptonote::core &c, size_t ev_index)
-  {
-    DEFINE_TESTS_ERROR_CONTEXT("check_prefer_deregisters");
-    const auto tx_count = c.get_pool().get_transactions_count();
-    cryptonote::block full_blk;
-    {
+      {
+      DEFINE_TESTS_ERROR_CONTEXT("check_prefer_deregisters");
+      const auto tx_count = c.get_pool().get_transactions_count();
+      cryptonote::block full_blk;
+      {
       cryptonote::difficulty_type diffic;
       uint64_t height;
       uint64_t expected_reward;
       cryptonote::blobdata extra_nonce;
       c.create_next_miner_block_template(full_blk, miner.get_keys().m_account_address, diffic, height, expected_reward, extra_nonce);
-    }
+      }
 
-    map_hash2tx_t mtx;
-    {
+      map_hash2tx_t mtx;
+      {
       std::vector<cryptonote::block> chain;
       CHECK_TEST_CONDITION(find_block_chain(events, chain, mtx, get_block_hash(var::get<cryptonote::block>(events[0]))));
-    }
+      }
 
-    const auto deregister_count =
+      const auto deregister_count =
       std::count_if(full_blk.tx_hashes.begin(), full_blk.tx_hashes.end(), [&mtx](const crypto::hash& tx_hash) {
-        return mtx[tx_hash]->type == cryptonote::txtype::state_change;
-      });
+          return mtx[tx_hash]->type == cryptonote::txtype::state_change;
+          });
 
-    CHECK_TEST_CONDITION(tx_count == 8);
-    CHECK_EQ(full_blk.tx_hashes.size(), 7);
-    CHECK_EQ(deregister_count, 2);
-    return true;
-  });
+      CHECK_TEST_CONDITION(tx_count == 8);
+      CHECK_EQ(full_blk.tx_hashes.size(), 7);
+      CHECK_EQ(deregister_count, 2);
+      return true;
+      });
   return true;
 }
 
@@ -895,9 +895,9 @@ bool oxen_core_test_deregister_too_old::generate(std::vector<test_event_entry>& 
   /// tests we must add specify transactions manually), which should exercise the same validation code and reject the
   /// block
   gen.create_and_add_next_block({dereg_tx},
-                nullptr /*checkpoint*/,
-                false /*can_be_added_to_blockchain*/,
-                "Trying to add a block with an old deregister sitting in the pool that was invalidated due to old age");
+      nullptr /*checkpoint*/,
+      false /*can_be_added_to_blockchain*/,
+      "Trying to add a block with an old deregister sitting in the pool that was invalidated due to old age");
   return true;
 }
 
@@ -917,7 +917,7 @@ bool oxen_core_test_deregister_zero_fee::generate(std::vector<test_event_entry> 
   gen.create_and_add_next_block(reg_txs);
   const auto deregister_pub_key = gen.top_quorum().obligations->workers[0];
   cryptonote::transaction const invalid_deregister =
-      gen.create_state_change_tx(service_nodes::new_state::deregister, deregister_pub_key, 0, 0, -1 /*height*/, {} /*voters*/, MK_COINS(1) /*fee*/);
+    gen.create_state_change_tx(service_nodes::new_state::deregister, deregister_pub_key, 0, 0, -1 /*height*/, {} /*voters*/, MK_COINS(1) /*fee*/);
   gen.add_tx(invalid_deregister, false /*can_be_added_to_blockchain*/, "Deregister transactions with non-zero fee can NOT be added to the blockchain");
   return true;
 }
@@ -933,7 +933,7 @@ bool oxen_core_test_deregister_on_split::generate(std::vector<test_event_entry> 
 
   gen.add_blocks_until_version(hard_forks.back().version);
   gen.add_mined_money_unlock_blocks();
- 
+
   add_service_nodes(gen, service_nodes::CHECKPOINT_QUORUM_SIZE + 1, hard_forks.back().version);
   gen.create_and_add_next_block(); // Can't change service node state on the same height it was registered in
   auto fork = gen;
@@ -967,21 +967,21 @@ bool oxen_core_test_deregister_on_split::generate(std::vector<test_event_entry> 
   fork.add_service_node_checkpoint(fork.height(), service_nodes::CHECKPOINT_MIN_VOTES);
 
   oxen_register_callback(events, "test_on_split", [expected_tx_hash, expected_block_hash](cryptonote::core &c, size_t ev_index)
-  {
-    /// Check that the deregister transaction is the one from the alternative branch
-    DEFINE_TESTS_ERROR_CONTEXT("test_on_split");
+      {
+      /// Check that the deregister transaction is the one from the alternative branch
+      DEFINE_TESTS_ERROR_CONTEXT("test_on_split");
 
-    /// get the block with the deregister
-    bool orphan = false;
-    cryptonote::block blk;
-    CHECK_TEST_CONDITION(c.get_block_by_hash(expected_block_hash, blk, &orphan));
+      /// get the block with the deregister
+      bool orphan = false;
+      cryptonote::block blk;
+      CHECK_TEST_CONDITION(c.get_block_by_hash(expected_block_hash, blk, &orphan));
 
-    /// find the deregister tx:
-    const auto found_tx_hash = std::find(blk.tx_hashes.begin(), blk.tx_hashes.end(), expected_tx_hash);
-    CHECK_TEST_CONDITION(found_tx_hash != blk.tx_hashes.end());
-    CHECK_EQ(*found_tx_hash, expected_tx_hash); /// check that it is the expected one
-    return true;
-  });
+      /// find the deregister tx:
+      const auto found_tx_hash = std::find(blk.tx_hashes.begin(), blk.tx_hashes.end(), expected_tx_hash);
+      CHECK_TEST_CONDITION(found_tx_hash != blk.tx_hashes.end());
+      CHECK_EQ(*found_tx_hash, expected_tx_hash); /// check that it is the expected one
+      return true;
+      });
 
   return true;
 }
@@ -1021,15 +1021,15 @@ bool oxen_core_test_state_change_ip_penalty_disallow_dupes::generate(std::vector
 }
 
 static bool verify_ons_mapping_record(char const *perr_context,
-                                      ons::mapping_record const &record,
-                                      ons::mapping_type type,
-                                      std::string const &name,
-                                      ons::mapping_value const &value,
-                                      uint64_t update_height,
-                                      std::optional<uint64_t> expiration_height,
-                                      crypto::hash const &txid,
-                                      ons::generic_owner const &owner,
-                                      ons::generic_owner const &backup_owner)
+    ons::mapping_record const &record,
+    ons::mapping_type type,
+    std::string const &name,
+    ons::mapping_value const &value,
+    uint64_t update_height,
+    std::optional<uint64_t> expiration_height,
+    crypto::hash const &txid,
+    ons::generic_owner const &owner,
+    ons::generic_owner const &backup_owner)
 {
   CHECK_EQ(record.loaded,          true);
   CHECK_EQ(record.type,            type);
@@ -1116,8 +1116,8 @@ bool oxen_name_system_expiration::generate(std::vector<test_event_entry> &events
 
   ons_keys_t miner_key = make_ons_keys(miner);
   for (auto mapping_type = ons::mapping_type::lokinet;
-       mapping_type     <= ons::mapping_type::lokinet_10years;
-       mapping_type      = static_cast<ons::mapping_type>(static_cast<uint16_t>(mapping_type) + 1))
+      mapping_type     <= ons::mapping_type::lokinet_10years;
+      mapping_type      = static_cast<ons::mapping_type>(static_cast<uint16_t>(mapping_type) + 1))
   {
     std::string const name     = "mydomain.loki";
     if (ons::mapping_type_allowed(gen.hardfork(), mapping_type))
@@ -1131,42 +1131,42 @@ bool oxen_name_system_expiration::generate(std::vector<test_event_entry> &events
       std::string name_hash = ons::name_to_base64_hash(name);
 
       oxen_register_callback(events, "check_ons_entries", [=](cryptonote::core &c, size_t ev_index)
-      {
-        DEFINE_TESTS_ERROR_CONTEXT("check_ons_entries");
-        ons::name_system_db &ons_db = c.get_blockchain_storage().name_system_db();
-        ons::owner_record owner = ons_db.get_owner_by_key(miner_key.owner);
-        CHECK_EQ(owner.loaded, true);
-        CHECK_EQ(owner.id, 1);
-        CHECK_TEST_CONDITION_MSG(miner_key.owner == owner.address,
-                                 miner_key.owner.to_string(cryptonote::FAKECHAIN)
-                                     << " == " << owner.address.to_string(cryptonote::FAKECHAIN));
+          {
+          DEFINE_TESTS_ERROR_CONTEXT("check_ons_entries");
+          ons::name_system_db &ons_db = c.get_blockchain_storage().name_system_db();
+          ons::owner_record owner = ons_db.get_owner_by_key(miner_key.owner);
+          CHECK_EQ(owner.loaded, true);
+          CHECK_EQ(owner.id, 1);
+          CHECK_TEST_CONDITION_MSG(miner_key.owner == owner.address,
+              miner_key.owner.to_string(cryptonote::FAKECHAIN)
+              << " == " << owner.address.to_string(cryptonote::FAKECHAIN));
 
-        ons::mapping_record record = ons_db.get_mapping(mapping_type, name_hash);
-        CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, record, ons::mapping_type::lokinet, name, miner_key.lokinet_value, height_of_ons_entry, height_of_ons_entry + lokinet_expiry(mapping_type), tx_hash, miner_key.owner, {} /*backup_owner*/));
-        return true;
-      });
+          ons::mapping_record record = ons_db.get_mapping(mapping_type, name_hash);
+          CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, record, ons::mapping_type::lokinet, name, miner_key.lokinet_value, height_of_ons_entry, height_of_ons_entry + lokinet_expiry(mapping_type), tx_hash, miner_key.owner, {} /*backup_owner*/));
+          return true;
+          });
 
       while (gen.height() <= expected_expiry_block)
         gen.create_and_add_next_block();
 
       oxen_register_callback(events, "check_expired", [=, blockchain_height = gen.chain_height()](cryptonote::core &c, size_t ev_index)
-      {
-        DEFINE_TESTS_ERROR_CONTEXT("check_expired");
-        ons::name_system_db &ons_db = c.get_blockchain_storage().name_system_db();
+          {
+          DEFINE_TESTS_ERROR_CONTEXT("check_expired");
+          ons::name_system_db &ons_db = c.get_blockchain_storage().name_system_db();
 
-        // TODO(oxen): We should probably expire owners that no longer have any mappings remaining
-        ons::owner_record owner = ons_db.get_owner_by_key(miner_key.owner);
-        CHECK_EQ(owner.loaded, true);
-        CHECK_EQ(owner.id, 1);
-        CHECK_TEST_CONDITION_MSG(miner_key.owner == owner.address,
-                                 miner_key.owner.to_string(cryptonote::FAKECHAIN)
-                                     << " == " << owner.address.to_string(cryptonote::FAKECHAIN));
+          // TODO(oxen): We should probably expire owners that no longer have any mappings remaining
+          ons::owner_record owner = ons_db.get_owner_by_key(miner_key.owner);
+          CHECK_EQ(owner.loaded, true);
+          CHECK_EQ(owner.id, 1);
+          CHECK_TEST_CONDITION_MSG(miner_key.owner == owner.address,
+              miner_key.owner.to_string(cryptonote::FAKECHAIN)
+              << " == " << owner.address.to_string(cryptonote::FAKECHAIN));
 
-        ons::mapping_record record = ons_db.get_mapping(mapping_type, name_hash);
-        CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, record, ons::mapping_type::lokinet, name, miner_key.lokinet_value, height_of_ons_entry, height_of_ons_entry + lokinet_expiry(mapping_type), tx_hash, miner_key.owner, {} /*backup_owner*/));
-        CHECK_EQ(record.active(blockchain_height), false);
-        return true;
-      });
+          ons::mapping_record record = ons_db.get_mapping(mapping_type, name_hash);
+          CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, record, ons::mapping_type::lokinet, name, miner_key.lokinet_value, height_of_ons_entry, height_of_ons_entry + lokinet_expiry(mapping_type), tx_hash, miner_key.owner, {} /*backup_owner*/));
+          CHECK_EQ(record.active(blockchain_height), false);
+          return true;
+          });
     }
     else
     {
@@ -1249,48 +1249,48 @@ bool oxen_name_system_get_mappings_by_owner::generate(std::vector<test_event_ent
   uint64_t wallet_height = gen.height();
 
   oxen_register_callback(events, "check_ons_entries", [=](cryptonote::core &c, size_t ev_index)
-  {
-    const char* perr_context = "check_ons_entries";
-    ons::name_system_db &ons_db = c.get_blockchain_storage().name_system_db();
-    std::vector<ons::mapping_record> records = ons_db.get_mappings_by_owner(bob_key.owner);
+      {
+      const char* perr_context = "check_ons_entries";
+      ons::name_system_db &ons_db = c.get_blockchain_storage().name_system_db();
+      std::vector<ons::mapping_record> records = ons_db.get_mappings_by_owner(bob_key.owner);
 
-    size_t expected_size = 0;
-    auto netv = get_network_version(c.get_nettype(), c.get_current_blockchain_height());
-    if (ons::mapping_type_allowed(netv, ons::mapping_type::session)) expected_size += 2;
-    if (ons::mapping_type_allowed(netv, ons::mapping_type::wallet)) expected_size += 2;
-    if (ons::mapping_type_allowed(netv, ons::mapping_type::lokinet)) expected_size += 2;
-    CHECK_EQ(records.size(), expected_size);
+      size_t expected_size = 0;
+      auto netv = get_network_version(c.get_nettype(), c.get_current_blockchain_height());
+      if (ons::mapping_type_allowed(netv, ons::mapping_type::session)) expected_size += 2;
+      if (ons::mapping_type_allowed(netv, ons::mapping_type::wallet)) expected_size += 2;
+      if (ons::mapping_type_allowed(netv, ons::mapping_type::lokinet)) expected_size += 2;
+      CHECK_EQ(records.size(), expected_size);
 
-    std::sort(records.begin(), records.end(), [](const auto& a, const auto& b) {
-      return std::make_tuple(a.update_height, a.name_hash)
-           < std::make_tuple(b.update_height, b.name_hash);
-    });
+      std::sort(records.begin(), records.end(), [](const auto& a, const auto& b) {
+          return std::make_tuple(a.update_height, a.name_hash)
+          < std::make_tuple(b.update_height, b.name_hash);
+          });
 
-    if (ons::mapping_type_allowed(netv, ons::mapping_type::session))
-    {
+      if (ons::mapping_type_allowed(netv, ons::mapping_type::session))
+      {
       CHECK_EQ(records[0].name_hash, session_name_hash1);
       CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, records[0], ons::mapping_type::session, session_name1, bob_key.session_value, session_height, std::nullopt, session_name1_txid, bob_key.owner, {} /*backup_owner*/));
       CHECK_EQ(records[1].name_hash, session_name_hash2);
       CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, records[1], ons::mapping_type::session, session_name2, bob_key.session_value, session_height, std::nullopt, session_name2_txid, bob_key.owner, {} /*backup_owner*/));
-    }
+      }
 
-    if (ons::mapping_type_allowed(netv, ons::mapping_type::lokinet))
-    {
-      CHECK_EQ(records[2].name_hash, lokinet_name_hash1);
-      CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, records[2], ons::mapping_type::lokinet, lokinet_name1, bob_key.lokinet_value, lokinet_height, lokinet_height + lokinet_expiry(ons::mapping_type::lokinet), lokinet_name1_txid, bob_key.owner, {} /*backup_owner*/));
-      CHECK_EQ(records[3].name_hash, lokinet_name_hash2);
-      CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, records[3], ons::mapping_type::lokinet, lokinet_name2, bob_key.lokinet_value, lokinet_height, lokinet_height + lokinet_expiry(ons::mapping_type::lokinet_5years), lokinet_name2_txid, bob_key.owner, {} /*backup_owner*/));
-    }
+      if (ons::mapping_type_allowed(netv, ons::mapping_type::lokinet))
+      {
+        CHECK_EQ(records[2].name_hash, lokinet_name_hash1);
+        CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, records[2], ons::mapping_type::lokinet, lokinet_name1, bob_key.lokinet_value, lokinet_height, lokinet_height + lokinet_expiry(ons::mapping_type::lokinet), lokinet_name1_txid, bob_key.owner, {} /*backup_owner*/));
+        CHECK_EQ(records[3].name_hash, lokinet_name_hash2);
+        CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, records[3], ons::mapping_type::lokinet, lokinet_name2, bob_key.lokinet_value, lokinet_height, lokinet_height + lokinet_expiry(ons::mapping_type::lokinet_5years), lokinet_name2_txid, bob_key.owner, {} /*backup_owner*/));
+      }
 
-    if (ons::mapping_type_allowed(netv, ons::mapping_type::wallet))
-    {
-      CHECK_EQ(records[4].name_hash, wallet_name_hash1);
-      CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, records[4], ons::mapping_type::wallet, wallet_name1, bob_key.wallet_value, wallet_height, std::nullopt, wallet_name1_txid, bob_key.owner, {} /*backup_owner*/));
-      CHECK_EQ(records[5].name_hash, wallet_name_hash2);
-      CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, records[5], ons::mapping_type::wallet, wallet_name2, bob_key.wallet_value, wallet_height, std::nullopt, wallet_name2_txid, bob_key.owner, {} /*backup_owner*/));
-    }
-    return true;
-  });
+      if (ons::mapping_type_allowed(netv, ons::mapping_type::wallet))
+      {
+        CHECK_EQ(records[4].name_hash, wallet_name_hash1);
+        CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, records[4], ons::mapping_type::wallet, wallet_name1, bob_key.wallet_value, wallet_height, std::nullopt, wallet_name1_txid, bob_key.owner, {} /*backup_owner*/));
+        CHECK_EQ(records[5].name_hash, wallet_name_hash2);
+        CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, records[5], ons::mapping_type::wallet, wallet_name2, bob_key.wallet_value, wallet_height, std::nullopt, wallet_name2_txid, bob_key.owner, {} /*backup_owner*/));
+      }
+      return true;
+      });
 
   return true;
 }
@@ -1346,21 +1346,21 @@ bool oxen_name_system_get_mappings_by_owners::generate(std::vector<test_event_en
   gen.add_n_blocks(10);
 
   oxen_register_callback(events, "check_ons_entries", [=](cryptonote::core &c, size_t ev_index)
-  {
-    DEFINE_TESTS_ERROR_CONTEXT("check_ons_entries");
-    ons::name_system_db &ons_db = c.get_blockchain_storage().name_system_db();
-    std::vector<ons::mapping_record> records = ons_db.get_mappings_by_owners({bob_key.owner, miner_key.owner});
-    CHECK_EQ(records.size(), 3);
-    std::sort(records.begin(), records.end(), [](ons::mapping_record const &lhs, ons::mapping_record const &rhs) {
-      return lhs.update_height < rhs.update_height;
-    });
+      {
+      DEFINE_TESTS_ERROR_CONTEXT("check_ons_entries");
+      ons::name_system_db &ons_db = c.get_blockchain_storage().name_system_db();
+      std::vector<ons::mapping_record> records = ons_db.get_mappings_by_owners({bob_key.owner, miner_key.owner});
+      CHECK_EQ(records.size(), 3);
+      std::sort(records.begin(), records.end(), [](ons::mapping_record const &lhs, ons::mapping_record const &rhs) {
+          return lhs.update_height < rhs.update_height;
+          });
 
-    int index = 0;
-    CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, records[index++], ons::mapping_type::session, session_name1, bob_key.session_value, session_height1, std::nullopt, session_tx_hash1, bob_key.owner, {}));
-    CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, records[index++], ons::mapping_type::session, session_name2, bob_key.session_value, session_height2, std::nullopt, session_tx_hash2, bob_key.owner, {}));
-    CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, records[index++], ons::mapping_type::session, session_name3, miner_key.session_value, session_height3, std::nullopt, session_tx_hash3, miner_key.owner, {}));
-    return true;
-  });
+      int index = 0;
+      CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, records[index++], ons::mapping_type::session, session_name1, bob_key.session_value, session_height1, std::nullopt, session_tx_hash1, bob_key.owner, {}));
+      CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, records[index++], ons::mapping_type::session, session_name2, bob_key.session_value, session_height2, std::nullopt, session_tx_hash2, bob_key.owner, {}));
+      CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, records[index++], ons::mapping_type::session, session_name3, miner_key.session_value, session_height3, std::nullopt, session_tx_hash3, miner_key.owner, {}));
+      return true;
+      });
 
   return true;
 }
@@ -1394,15 +1394,15 @@ bool oxen_name_system_get_mappings::generate(std::vector<test_event_entry> &even
   uint64_t session_height = gen.height();
 
   oxen_register_callback(events, "check_ons_entries", [bob_key, session_height, session_name1, session_tx_hash](cryptonote::core &c, size_t ev_index)
-  {
-    DEFINE_TESTS_ERROR_CONTEXT("check_ons_entries");
-    ons::name_system_db &ons_db = c.get_blockchain_storage().name_system_db();
-    std::string session_name_hash = ons::name_to_base64_hash(tools::lowercase_ascii_string(session_name1));
-    std::vector<ons::mapping_record> records = ons_db.get_mappings({ons::mapping_type::session}, session_name_hash);
-    CHECK_EQ(records.size(), 1);
-    CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, records[0], ons::mapping_type::session, session_name1, bob_key.session_value, session_height, std::nullopt, session_tx_hash, bob_key.owner, {} /*backup_owner*/));
-    return true;
-  });
+      {
+      DEFINE_TESTS_ERROR_CONTEXT("check_ons_entries");
+      ons::name_system_db &ons_db = c.get_blockchain_storage().name_system_db();
+      std::string session_name_hash = ons::name_to_base64_hash(tools::lowercase_ascii_string(session_name1));
+      std::vector<ons::mapping_record> records = ons_db.get_mappings({ons::mapping_type::session}, session_name_hash);
+      CHECK_EQ(records.size(), 1);
+      CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, records[0], ons::mapping_type::session, session_name1, bob_key.session_value, session_height, std::nullopt, session_tx_hash, bob_key.owner, {} /*backup_owner*/));
+      return true;
+      });
 
   return true;
 }
@@ -1453,35 +1453,35 @@ bool oxen_name_system_handles_duplicate_in_ons_db::generate(std::vector<test_eve
   }
 
   oxen_register_callback(events, "check_ons_entries", [=, blockchain_height=gen.chain_height()](cryptonote::core &c, size_t ev_index)
-  {
-    DEFINE_TESTS_ERROR_CONTEXT("check_ons_entries");
-    ons::name_system_db &ons_db = c.get_blockchain_storage().name_system_db();
+      {
+      DEFINE_TESTS_ERROR_CONTEXT("check_ons_entries");
+      ons::name_system_db &ons_db = c.get_blockchain_storage().name_system_db();
 
-    ons::owner_record owner = ons_db.get_owner_by_key(miner_key.owner);
-    CHECK_EQ(owner.loaded, true);
-    CHECK_EQ(owner.id, 1);
-    CHECK_TEST_CONDITION_MSG(miner_key.owner == owner.address,
-                             miner_key.owner.to_string(cryptonote::FAKECHAIN)
-                                 << " == " << owner.address.to_string(cryptonote::FAKECHAIN));
+      ons::owner_record owner = ons_db.get_owner_by_key(miner_key.owner);
+      CHECK_EQ(owner.loaded, true);
+      CHECK_EQ(owner.id, 1);
+      CHECK_TEST_CONDITION_MSG(miner_key.owner == owner.address,
+          miner_key.owner.to_string(cryptonote::FAKECHAIN)
+          << " == " << owner.address.to_string(cryptonote::FAKECHAIN));
 
-    std::string session_name_hash = ons::name_to_base64_hash(session_name);
-    ons::mapping_record record1 = ons_db.get_mapping(ons::mapping_type::session, session_name_hash);
-    CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, record1, ons::mapping_type::session, session_name, bob_key.session_value, height_of_ons_entry, std::nullopt, session_tx_hash, miner_key.owner, {} /*backup_owner*/));
-    CHECK_EQ(record1.owner_id, owner.id);
+      std::string session_name_hash = ons::name_to_base64_hash(session_name);
+      ons::mapping_record record1 = ons_db.get_mapping(ons::mapping_type::session, session_name_hash);
+      CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, record1, ons::mapping_type::session, session_name, bob_key.session_value, height_of_ons_entry, std::nullopt, session_tx_hash, miner_key.owner, {} /*backup_owner*/));
+      CHECK_EQ(record1.owner_id, owner.id);
 
-    auto netv = get_network_version(c.get_nettype(), c.get_current_blockchain_height());
-    if (ons::mapping_type_allowed(netv, ons::mapping_type::lokinet))
-    {
+      auto netv = get_network_version(c.get_nettype(), c.get_current_blockchain_height());
+      if (ons::mapping_type_allowed(netv, ons::mapping_type::lokinet))
+      {
       ons::mapping_record record2 = ons_db.get_mapping(ons::mapping_type::lokinet, session_name_hash);
       CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, record2, ons::mapping_type::lokinet, lokinet_name, miner_key.lokinet_value, height_of_ons_entry, height_of_ons_entry + lokinet_expiry(ons::mapping_type::lokinet_2years), lokinet_tx_hash, miner_key.owner, {} /*backup_owner*/));
       CHECK_EQ(record2.owner_id, owner.id);
       CHECK_EQ(record2.active(blockchain_height), true);
-    }
+      }
 
-    ons::owner_record owner2 = ons_db.get_owner_by_key(bob_key.owner);
-    CHECK_EQ(owner2.loaded, false);
-    return true;
-  });
+      ons::owner_record owner2 = ons_db.get_owner_by_key(bob_key.owner);
+      CHECK_EQ(owner2.loaded, false);
+      return true;
+      });
   return true;
 }
 
@@ -1532,11 +1532,11 @@ bool oxen_name_system_invalid_tx_extra_params::generate(std::vector<test_event_e
   // Manually construct transaction with invalid tx extra
   {
     auto make_ons_tx_with_custom_extra = [&](oxen_chain_generator &gen,
-                                             std::vector<test_event_entry> &events,
-                                             cryptonote::account_base const &src,
-                                             cryptonote::tx_extra_oxen_name_system &data,
-                                             bool valid,
-                                             char const *reason) -> void {
+        std::vector<test_event_entry> &events,
+        cryptonote::account_base const &src,
+        cryptonote::tx_extra_oxen_name_system &data,
+        bool valid,
+        char const *reason) -> void {
       uint64_t new_height    = cryptonote::get_block_height(gen.top().block) + 1;
       uint8_t new_hf_version = gen.get_hf_version_at(new_height);
       uint64_t burn_requirement = ons::burn_needed(new_hf_version, static_cast<ons::mapping_type>(data.type));
@@ -1547,10 +1547,10 @@ bool oxen_name_system_invalid_tx_extra_params::generate(std::vector<test_event_e
 
       cryptonote::transaction tx = {};
       oxen_tx_builder(events, tx, gen.top().block, src /*from*/, src.get_keys().m_account_address, 0, new_hf_version)
-          .with_tx_type(cryptonote::txtype::oxen_name_system)
-          .with_extra(extra)
-          .with_fee(burn_requirement + TESTS_DEFAULT_FEE)
-          .build();
+        .with_tx_type(cryptonote::txtype::oxen_name_system)
+        .with_extra(extra)
+        .with_fee(burn_requirement + TESTS_DEFAULT_FEE)
+        .build();
 
       gen.add_tx(tx, valid /*can_be_added_to_blockchain*/, reason, false /*kept_by_block*/);
     };
@@ -1700,33 +1700,33 @@ bool oxen_name_system_large_reorg::generate(std::vector<test_event_entry> &event
     first_ons_height = gen.height();
 
     oxen_register_callback(events, "check_first_ons_entries", [=](cryptonote::core &c, size_t ev_index)
-    {
-      DEFINE_TESTS_ERROR_CONTEXT("check_first_ons_entries");
-      ons::name_system_db &ons_db        = c.get_blockchain_storage().name_system_db();
-      std::vector<ons::mapping_record> records = ons_db.get_mappings_by_owner(miner_key.owner);
-      CHECK_EQ(ons_db.height(), first_ons_height);
+        {
+        DEFINE_TESTS_ERROR_CONTEXT("check_first_ons_entries");
+        ons::name_system_db &ons_db        = c.get_blockchain_storage().name_system_db();
+        std::vector<ons::mapping_record> records = ons_db.get_mappings_by_owner(miner_key.owner);
+        CHECK_EQ(ons_db.height(), first_ons_height);
 
-      size_t expected_size = 1;
-      auto netv = get_network_version(c.get_nettype(), c.get_current_blockchain_height());
-      if (ons::mapping_type_allowed(netv, ons::mapping_type::wallet)) expected_size += 1;
-      if (ons::mapping_type_allowed(netv, ons::mapping_type::lokinet)) expected_size += 1;
-      CHECK_EQ(records.size(), expected_size);
+        size_t expected_size = 1;
+        auto netv = get_network_version(c.get_nettype(), c.get_current_blockchain_height());
+        if (ons::mapping_type_allowed(netv, ons::mapping_type::wallet)) expected_size += 1;
+        if (ons::mapping_type_allowed(netv, ons::mapping_type::lokinet)) expected_size += 1;
+        CHECK_EQ(records.size(), expected_size);
 
-      for (ons::mapping_record const &record : records)
-      {
+        for (ons::mapping_record const &record : records)
+        {
         if (record.type == ons::mapping_type::session)
-          CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, record, ons::mapping_type::session, session_name1, miner_key.session_value, first_ons_height, std::nullopt, session_tx_hash1, miner_key.owner, {} /*backup_owner*/));
+        CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, record, ons::mapping_type::session, session_name1, miner_key.session_value, first_ons_height, std::nullopt, session_tx_hash1, miner_key.owner, {} /*backup_owner*/));
         else if (record.type == ons::mapping_type::lokinet)
-          CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, record, ons::mapping_type::lokinet, lokinet_name1, miner_key.lokinet_value, first_ons_height, first_ons_height + lokinet_expiry(ons::mapping_type::lokinet_10years), lokinet_tx_hash1, miner_key.owner, {} /*backup_owner*/));
+        CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, record, ons::mapping_type::lokinet, lokinet_name1, miner_key.lokinet_value, first_ons_height, first_ons_height + lokinet_expiry(ons::mapping_type::lokinet_10years), lokinet_tx_hash1, miner_key.owner, {} /*backup_owner*/));
         else if (record.type == ons::mapping_type::wallet)
-          CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, record, ons::mapping_type::wallet, wallet_name1, miner_key.wallet_value, first_ons_height, std::nullopt, wallet_tx_hash1, miner_key.owner, {} /*backup_owner*/));
+        CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, record, ons::mapping_type::wallet, wallet_name1, miner_key.wallet_value, first_ons_height, std::nullopt, wallet_tx_hash1, miner_key.owner, {} /*backup_owner*/));
         else
         {
           assert(false);
         }
-      }
-      return true;
-    });
+        }
+        return true;
+        });
   }
 
   // NOTE: Generate and add the second round of (transactions + block) to the blockchain, renew lokinet and add bob's session, update miner's session value to other's session value
@@ -1755,49 +1755,49 @@ bool oxen_name_system_large_reorg::generate(std::vector<test_event_entry> &event
     second_ons_height = gen.height();
 
     oxen_register_callback(events, "check_second_ons_entries", [=](cryptonote::core &c, size_t ev_index)
-    {
-      DEFINE_TESTS_ERROR_CONTEXT("check_second_ons_entries");
-      ons::name_system_db &ons_db = c.get_blockchain_storage().name_system_db();
-      CHECK_EQ(ons_db.height(), second_ons_height);
+        {
+        DEFINE_TESTS_ERROR_CONTEXT("check_second_ons_entries");
+        ons::name_system_db &ons_db = c.get_blockchain_storage().name_system_db();
+        CHECK_EQ(ons_db.height(), second_ons_height);
 
-      // NOTE: Check miner's record
-      {
+        // NOTE: Check miner's record
+        {
         std::vector<ons::mapping_record> records = ons_db.get_mappings_by_owner(miner_key.owner);
         for (ons::mapping_record const &record : records)
         {
-          if (record.type == ons::mapping_type::session)
-            CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, record, ons::mapping_type::session, session_name1, other_key.session_value, second_ons_height, std::nullopt, session_tx_hash3, miner_key.owner, {} /*backup_owner*/));
-          else if (record.type == ons::mapping_type::lokinet)
-            CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, record, ons::mapping_type::lokinet, lokinet_name1, miner_key.lokinet_value, second_ons_height, first_ons_height + lokinet_expiry(ons::mapping_type::lokinet_5years) + lokinet_expiry(ons::mapping_type::lokinet_10years), lokinet_tx_hash2, miner_key.owner, {} /*backup_owner*/));
-          else if (record.type == ons::mapping_type::wallet)
-            CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, record, ons::mapping_type::wallet, wallet_name1, miner_key.wallet_value, first_ons_height, std::nullopt, wallet_tx_hash1, miner_key.owner, {} /*backup_owner*/));
-          else
-          {
-            assert(false);
-          }
+        if (record.type == ons::mapping_type::session)
+        CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, record, ons::mapping_type::session, session_name1, other_key.session_value, second_ons_height, std::nullopt, session_tx_hash3, miner_key.owner, {} /*backup_owner*/));
+        else if (record.type == ons::mapping_type::lokinet)
+        CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, record, ons::mapping_type::lokinet, lokinet_name1, miner_key.lokinet_value, second_ons_height, first_ons_height + lokinet_expiry(ons::mapping_type::lokinet_5years) + lokinet_expiry(ons::mapping_type::lokinet_10years), lokinet_tx_hash2, miner_key.owner, {} /*backup_owner*/));
+        else if (record.type == ons::mapping_type::wallet)
+        CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, record, ons::mapping_type::wallet, wallet_name1, miner_key.wallet_value, first_ons_height, std::nullopt, wallet_tx_hash1, miner_key.owner, {} /*backup_owner*/));
+        else
+        {
+        assert(false);
         }
-      }
+        }
+        }
 
-      // NOTE: Check bob's records
-      {
-        std::vector<ons::mapping_record> records = ons_db.get_mappings_by_owner(bob_key.owner);
-        CHECK_EQ(records.size(), 1);
-        CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, records[0], ons::mapping_type::session, bob_session_name1, bob_key.session_value, second_ons_height, std::nullopt, session_tx_hash2, bob_key.owner, {} /*backup_owner*/));
-      }
+        // NOTE: Check bob's records
+        {
+          std::vector<ons::mapping_record> records = ons_db.get_mappings_by_owner(bob_key.owner);
+          CHECK_EQ(records.size(), 1);
+          CHECK_TEST_CONDITION(verify_ons_mapping_record(perr_context, records[0], ons::mapping_type::session, bob_session_name1, bob_key.session_value, second_ons_height, std::nullopt, session_tx_hash2, bob_key.owner, {} /*backup_owner*/));
+        }
 
-      return true;
-    });
+        return true;
+        });
   }
 
   oxen_register_callback(events, "trigger_blockchain_detach", [=](cryptonote::core &c, size_t ev_index)
-  {
-    DEFINE_TESTS_ERROR_CONTEXT("trigger_blockchain_detach");
-    cryptonote::Blockchain &blockchain = c.get_blockchain_storage();
+      {
+      DEFINE_TESTS_ERROR_CONTEXT("trigger_blockchain_detach");
+      cryptonote::Blockchain &blockchain = c.get_blockchain_storage();
 
-    // NOTE: Reorg to just before the 2nd round of ONS entries
-    uint64_t curr_height   = blockchain.get_current_blockchain_height();
-    uint64_t blocks_to_pop = curr_height - second_ons_height;
-    blockchain.pop_blocks(blocks_to_pop);
+      // NOTE: Reorg to just before the 2nd round of ONS entries
+      uint64_t curr_height   = blockchain.get_current_blockchain_height();
+      uint64_t blocks_to_pop = curr_height - second_ons_height;
+      blockchain.pop_blocks(blocks_to_pop);
     ons::name_system_db &ons_db  = blockchain.name_system_db();
     CHECK_EQ(ons_db.height(), blockchain.get_current_blockchain_height() - 1);
 
@@ -3615,12 +3615,60 @@ bool oxen_batch_sn_rewards_pop_blocks::generate(std::vector<test_event_entry> &e
 
     return true;
   });
+  return true;
+}
+
+bool oxen_batch_sn_rewards_pop_blocks_after_big_cycle::generate(std::vector<test_event_entry> &events)
+{
+
+  constexpr auto& conf = cryptonote::get_config(cryptonote::FAKECHAIN);
+  auto hard_forks = oxen_generate_hard_fork_table();
+  oxen_chain_generator gen(events, hard_forks);
+  const auto miner                      = gen.first_miner();
+  const auto alice                      = gen.add_account();
+  size_t alice_account_base_event_index = gen.event_index();
+  auto min_service_nodes = service_nodes::pulse_min_service_nodes(cryptonote::FAKECHAIN);
+
+  gen.add_blocks_until_version(hard_forks.back().version);
+  gen.add_n_blocks(10);
+  gen.add_mined_money_unlock_blocks();
+
+  for (auto i = 0u; i < min_service_nodes; ++i) {
+    const auto tx0 = gen.create_and_add_tx(miner, alice.get_keys().m_account_address, MK_COINS(101));
+    gen.create_and_add_next_block({tx0});
+  }
+  gen.add_transfer_unlock_blocks();
+
+  std::vector<cryptonote::transaction> registration_txs(service_nodes::pulse_min_service_nodes(cryptonote::FAKECHAIN));
+  for (auto i = 0u; i < min_service_nodes; ++i) {
+    registration_txs[i] = gen.create_and_add_registration_tx(alice);
+    gen.process_registration_tx(registration_txs[i], 12+i, hard_forks.back().version);
+  }
+  gen.create_and_add_next_block({registration_txs});
+
+  uint64_t next_payout = alice.get_keys().m_account_address.next_payout_height(gen.height(), conf.BATCHING_INTERVAL);
+  uint64_t more_blocks = next_payout - gen.height();
+
+  // There is an edge case where we get paid out before the node has been online long enough 
+  // if this is the case just cycle for another batching interval
+  if (more_blocks <= service_nodes::SERVICE_NODE_PAYABLE_AFTER_BLOCKS)
+    more_blocks += conf.BATCHING_INTERVAL;
+
+  for (auto i = 0u; i < more_blocks - 1; ++i)
+    gen.create_and_add_next_block();
+
+  // THIS BLOCK WILL CONTAIN THE BATCH TRANSACTION 
+  // get the amount that was to be paid here. Then when we
+  // pop back we want the same amount
+  oxen_blockchain_entry entry   = gen.create_next_block();
+  uint64_t amount = entry.block.miner_tx.vout[0].amount;
+  oxen_blockchain_entry &result = gen.add_block(entry);
 
   // Generate blocks up through a few payment cycles and check that we can get back safely.
   for (auto i = 0u; i < conf.BATCHING_INTERVAL * 3; ++i)
     gen.create_and_add_next_block();
 
-  oxen_register_callback(events, "pop_3_cycles", [=](cryptonote::core &c, size_t ev_index)
+  oxen_register_callback(events, "pop_3_cycles", [amount, &alice](cryptonote::core &c, size_t ev_index)
   {
     DEFINE_TESTS_ERROR_CONTEXT("pop_3_cycles");
     cryptonote::Blockchain& blockchain = c.get_blockchain_storage();
@@ -3628,13 +3676,18 @@ bool oxen_batch_sn_rewards_pop_blocks::generate(std::vector<test_event_entry> &e
     auto sqliteDB = blockchain.sqlite_db();
     CHECK_EQ((*sqliteDB).height, curr_height - 1);
 
-    blockchain.pop_blocks(conf.BATCHING_INTERVAL * 3);
+    blockchain.pop_blocks(conf.BATCHING_INTERVAL * 3 + 1);
 
-    CHECK_EQ((*sqliteDB).height, blockchain.get_current_blockchain_height() - 1);
-    CHECK_EQ((*sqliteDB).height, curr_height - more_blocks - 1);
 
-    auto records = (*sqliteDB).get_sn_payments(curr_height + 1);
-    CHECK_EQ((*records).size(), 0);
+    CHECK_EQ((*sqliteDB).height + 1, blockchain.get_current_blockchain_height());
+    CHECK_EQ((*sqliteDB).height + 1, curr_height - conf.BATCHING_INTERVAL * 3 - 1);
+
+    curr_height = blockchain.get_current_blockchain_height();
+
+    auto records = (*sqliteDB).get_sn_payments(curr_height);
+    CHECK_EQ((*records).size(), 1);
+    CHECK_EQ((*records)[0].amount, amount);
+    CHECK_EQ(tools::view_guts((*records)[0].address_info.address), tools::view_guts(alice.get_keys().m_account_address));
 
     return true;
   });

--- a/tests/core_tests/oxen_tests.cpp
+++ b/tests/core_tests/oxen_tests.cpp
@@ -3625,7 +3625,7 @@ bool oxen_batch_sn_rewards_pop_blocks_after_big_cycle::generate(std::vector<test
   auto hard_forks = oxen_generate_hard_fork_table();
   oxen_chain_generator gen(events, hard_forks);
   const auto miner                      = gen.first_miner();
-  const auto alice                      = gen.add_account();
+  const cryptonote::account_base alice  = gen.add_account();
   size_t alice_account_base_event_index = gen.event_index();
   auto min_service_nodes = service_nodes::pulse_min_service_nodes(cryptonote::FAKECHAIN);
 
@@ -3668,7 +3668,7 @@ bool oxen_batch_sn_rewards_pop_blocks_after_big_cycle::generate(std::vector<test
   for (auto i = 0u; i < conf.BATCHING_INTERVAL * 3; ++i)
     gen.create_and_add_next_block();
 
-  oxen_register_callback(events, "pop_3_cycles", [amount, &alice](cryptonote::core &c, size_t ev_index)
+  oxen_register_callback(events, "pop_3_cycles", [amount, alice](cryptonote::core &c, size_t ev_index)
   {
     DEFINE_TESTS_ERROR_CONTEXT("pop_3_cycles");
     cryptonote::Blockchain& blockchain = c.get_blockchain_storage();

--- a/tests/core_tests/oxen_tests.h
+++ b/tests/core_tests/oxen_tests.h
@@ -93,4 +93,5 @@ struct oxen_batch_sn_rewards                                                    
 struct oxen_batch_sn_rewards_bad_amount                                              : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };
 struct oxen_batch_sn_rewards_bad_address                                             : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };
 struct oxen_batch_sn_rewards_pop_blocks                                              : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };
+struct oxen_batch_sn_rewards_pop_blocks_after_big_cycle                              : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };
 

--- a/tests/unit_tests/sqlite.cpp
+++ b/tests/unit_tests/sqlite.cpp
@@ -59,7 +59,7 @@ TEST(SQLITE, AddSNRewards)
   t1.emplace_back(wallet_address.address, 16500000000/2, cryptonote::network_type::TESTNET);
 
   bool success = false; 
-  success = sqliteDB.add_sn_payments(t1, 1); 
+  success = sqliteDB.add_sn_payments(t1); 
   EXPECT_TRUE(success);
 
   EXPECT_TRUE(sqliteDB.batching_count() == 1);

--- a/utils/local-devnet/commands/getheight.py
+++ b/utils/local-devnet/commands/getheight.py
@@ -13,6 +13,7 @@ def instruct_daemon(method, params):
     headers = {'content-type': "application/json"}
     try:
         response = requests.request("POST", "http://"+config.listen_ip+":"+config.listen_port+"/json_rpc", data=payload, headers=headers)
+        # response = requests.request("POST", "http://"+config.listen_ip+":1165/json_rpc", data=payload, headers=headers)
         return json.loads(response.text)
     except requests.exceptions.RequestException as e:
         print(e)

--- a/utils/local-devnet/commands/gettimeblock.py
+++ b/utils/local-devnet/commands/gettimeblock.py
@@ -28,6 +28,8 @@ answer = instruct_daemon('get_last_block_header', params)
 
 # print(json.dumps(answer['result']['block_header']['timestamp'], indent=4, sort_keys=True))
 
+blockheight = answer['result']['block_header']['height']
+print("Block height: " + str(blockheight))
 blocktime = datetime.fromtimestamp(answer['result']['block_header']['timestamp'])
 print("Block time:   " + str(blocktime))
 

--- a/utils/local-devnet/service_node_network.py
+++ b/utils/local-devnet/service_node_network.py
@@ -133,7 +133,8 @@ class SNNetwork:
             self.mine(6*len(self.sns))
 
             self.print_wallet_balances()
-
+            self.mike.transfer(self.alice, 150000000000)
+            self.mike.transfer(self.bob, 150000000000)
             vprint("Submitting more service node registrations: ", end="", flush=True)
             for sn in self.sns[5:-1]:
                 self.mike.register_sn(sn)
@@ -144,7 +145,7 @@ class SNNetwork:
         self.print_wallet_balances()
 
         vprint("Mining 40 blocks (registrations + blink quorum lag) and waiting for nodes to sync")
-        self.sync_nodes(self.mine(40))
+        self.sync_nodes(self.mine(40), timeout=120)
 
         self.print_wallet_balances()
 
@@ -160,10 +161,20 @@ class SNNetwork:
             wait_for(lambda: all_service_nodes_proofed(sn), timeout=120)
             vprint(".", end="", flush=True, timestamp=False)
         vprint(timestamp=False)
-        for sn in self.sns[-1:]:
-            self.mike.register_sn(sn)
-            vprint(".", end="", flush=True, timestamp=False)
-        self.sync_nodes(self.mine(1), timeout=30)
+        # This commented out code will register the last SN through Mikes wallet (Has done every other SN)
+        # for sn in self.sns[-1:]:
+            # self.mike.register_sn(sn)
+            # vprint(".", end="", flush=True, timestamp=False)
+
+        # This commented out code will register the last SN through Bobs wallet (Has not done any others)
+        # self.bob.register_sn(self.sns[-1])
+
+        # This commented out code will register the last SN through Bobs wallet (Has not done any others)
+        # and also get alice to contribute 50% of the node with a 10% operator fee
+        self.bob.register_sn_for_contributions(self.sns[-1])
+        self.sync_nodes(self.mine(5), timeout=120)
+        self.alice.contribute_to_sn(self.sns[-1])
+        self.sync_nodes(self.mine(2), timeout=120)
         time.sleep(10)
         for sn in self.sns:
             sn.send_uptime_proof()


### PR DESCRIPTION
The batching of service node rewards allows us to drip feed rewards
to service nodes. Rather than accruing each service node 16.5 oxen every
time they are pulse block leader we now reward every node the 16.5 /
num_service_nodes every block and pay each wallet the full amount that
has been accrued after a period of time (Likely 3.5 days).

To spread each payment evenly we now pay the rewards based on the
address of the recipient. This modulus of their address determines which
block the address should be paid and by setting the interval to our
service_node_batching interval we can guarantee they will be paid out
regularly and evenly distribute the payments for all wallets over this
interval.