### PR TITLE
Add is-stake to wallet api

### DIFF
--- a/src/wallet/api/stake_unlock_result.h
+++ b/src/wallet/api/stake_unlock_result.h
@@ -12,7 +12,7 @@ class StakeUnlockResultImpl : public StakeUnlockResult
 public:
     StakeUnlockResultImpl(WalletImpl& w, tools::wallet2::request_stake_unlock_result res);
     StakeUnlockResultImpl();
-    ~StakeUnlockResultImpl();
+    ~StakeUnlockResultImpl() override;
 
     bool success() override;
     std::string msg() override;

--- a/src/wallet/api/transaction_history.cpp
+++ b/src/wallet/api/transaction_history.cpp
@@ -152,6 +152,7 @@ void TransactionHistoryImpl::refresh()
         ti->m_confirmations = (wallet_height > pd.m_block_height) ? wallet_height - pd.m_block_height : 0;
         ti->m_unlock_time = pd.m_unlock_time;
         ti->m_reward_type = from_pay_type(pd.m_type);
+        ti->m_is_stake = pd.m_type == wallet::pay_type::stake;
         m_history.push_back(ti);
 
     }
@@ -194,6 +195,7 @@ void TransactionHistoryImpl::refresh()
         ti->m_label = pd.m_subaddr_indices.size() == 1 ? w->get_subaddress_label({pd.m_subaddr_account, *pd.m_subaddr_indices.begin()}) : "";
         ti->m_timestamp = pd.m_timestamp;
         ti->m_confirmations = (wallet_height > pd.m_block_height) ? wallet_height - pd.m_block_height : 0;
+        ti->m_is_stake = pd.m_pay_type == wallet::pay_type::stake;
 
         // single output transaction might contain multiple transfers
         for (const auto &d: pd.m_dests) {
@@ -228,6 +230,7 @@ void TransactionHistoryImpl::refresh()
         ti->m_label = pd.m_subaddr_indices.size() == 1 ? w->get_subaddress_label({pd.m_subaddr_account, *pd.m_subaddr_indices.begin()}) : "";
         ti->m_timestamp = pd.m_timestamp;
         ti->m_confirmations = 0;
+        ti->m_is_stake = pd.m_pay_type == wallet::pay_type::stake;
         m_history.push_back(ti);
     }
     
@@ -253,6 +256,7 @@ void TransactionHistoryImpl::refresh()
         ti->m_timestamp = pd.m_timestamp;
         ti->m_confirmations = 0;
         ti->m_reward_type = from_pay_type(pd.m_type);
+        ti->m_is_stake = pd.m_type == wallet::pay_type::stake;
         m_history.push_back(ti);
         
         LOG_PRINT_L1(__FUNCTION__ << ": Unconfirmed payment found " << pd.m_amount);

--- a/src/wallet/api/transaction_info.cpp
+++ b/src/wallet/api/transaction_info.cpp
@@ -48,6 +48,7 @@ TransactionInfoImpl::TransactionInfoImpl()
       , m_pending(false)
       , m_failed(false)
       , m_reward_type(reward_type::unspecified)
+      , m_is_stake(false)
       , m_amount(0)
       , m_fee(0)
       , m_blockheight(0)
@@ -81,6 +82,12 @@ EXPORT
 bool TransactionInfoImpl::isMinerReward() const
 {
     return m_reward_type == reward_type::miner;
+}
+
+EXPORT
+bool TransactionInfoImpl::isStake() const
+{
+    return m_is_stake;
 }
 
 EXPORT

--- a/src/wallet/api/transaction_info.h
+++ b/src/wallet/api/transaction_info.h
@@ -66,12 +66,14 @@ public:
     virtual uint64_t unlockTime() const override;
     bool isServiceNodeReward() const override;
     bool isMinerReward() const override;
+    bool isStake() const override;
 
 private:
     int         m_direction;
     bool        m_pending;
     bool        m_failed;
     reward_type m_reward_type;                 // may have a value rather than `unspecified` after hf 10
+    bool        m_is_stake;
     uint64_t    m_amount;
     uint64_t    m_fee;
     uint64_t    m_blockheight;

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -118,6 +118,8 @@ struct StakeUnlockResult
   virtual bool success() = 0;
   virtual std::string msg() = 0;
   virtual PendingTransaction* ptx() = 0;
+
+  virtual ~StakeUnlockResult() = default;
 };
 
 /**

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -177,6 +177,7 @@ struct TransactionInfo
     virtual ~TransactionInfo() = 0;
     virtual bool isServiceNodeReward() const = 0;
     virtual bool isMinerReward() const = 0;
+    virtual bool isStake() const = 0;
     virtual int  direction() const = 0;
     virtual bool isPending() const = 0;
     virtual bool isFailed() const = 0;


### PR DESCRIPTION
Mobile wallet needs this to determine when a transaction is a stake rather than a transfer, otherwise it shows all stakes as outgoing transfers of 0.0.