### PR TITLE
Fix prepare_registration dust

### DIFF
--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -2215,6 +2215,9 @@ bool rpc_command_executor::prepare_registration(bool force_registration)
           break;
         }
 
+        if (portions > state.portions_remaining)
+          portions = state.portions_remaining;
+
         state.contributions.push_back(portions);
         state.portions_remaining -= portions;
         state.total_reserved_contributions += get_actual_amount(staking_requirement, portions);


### PR DESCRIPTION
We could get a rounding error in the contributor spots that would make the registration fail when passed to oxend.  This fixes it by restoring the missing logic that was accidentally dropped in the prepare_registration refactor.