### PR TITLE
Remove minor >= major block requirement for HF19+

### DIFF
--- a/src/cryptonote_basic/hardfork.cpp
+++ b/src/cryptonote_basic/hardfork.cpp
@@ -66,7 +66,7 @@ static constexpr std::array testnet_hard_forks =
   hard_fork{hf::hf18,                     0,   501750, 1616631051 }, // 2021-03-25 12:10 UTC
   hard_fork{hf::hf18,                     1,   578637, 1624040400 }, // 2021-06-18 18:20 UTC
   hard_fork{hf::hf19,                     0,   732355, 1650402545 },
-//  hard_fork{hf::hf19,                     1,   751553, 1652152424 },
+  hard_fork{hf::hf19,                     1,   751553, 1652152424 },
 };
 
 static constexpr std::array devnet_hard_forks =
@@ -163,13 +163,14 @@ get_ideal_block_version(network_type nettype, uint64_t height)
 {
   std::pair<hf, uint8_t> result;
   for (auto [it, end] = get_hard_forks(nettype); it != end; it++) {
-    if (it->height <= height)
+    if (it->height <= height) {
       result.first = it->version;
-    result.second = static_cast<uint8_t>(it->version);
+      result.second = it->snode_revision;
+    }
+    if (result.first < hf::hf19)
+      result.second = static_cast<uint8_t>(it->version);
   }
   return result;
 }
 
-
-}
-
+}  // namespace cryptonote

--- a/src/cryptonote_basic/hardfork.h
+++ b/src/cryptonote_basic/hardfork.h
@@ -92,8 +92,10 @@ namespace cryptonote
   }
 
   // Returns the "ideal" network version that we want to use on blocks we create, which is to use
-  // the required major version for major version and the maximum major version we know about as
-  // minor version.  If this seems a bit silly, it is, and will be changed in the future.
+  // the required major version and current minor version.  (Minor versions are sometimes used to
+  // change network features, but do not change the blockchain rules).
+  // Before HF19, the minor version must be >= the major version, and is set to the largest major
+  // version we know about.
   std::pair<hf, uint8_t> get_ideal_block_version(network_type nettype, uint64_t height);
 
 }  // namespace cryptonote

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -4159,8 +4159,9 @@ bool Blockchain::basic_block_checks(cryptonote::block const &blk, bool alt_block
     }
 
     // this is a cheap test
-    // HF19 TODO: remove the requirement that minor_version must be >= network version
-    if (auto v = get_network_version(blk_height); blk.major_version != v || blk.minor_version < static_cast<uint8_t>(v))
+    // HF19 TODO: after hardfork 19 occurs we can remove the second line of this test:
+    if (auto v = get_network_version(blk_height); blk.major_version != v ||
+            (v < hf::hf19 && blk.minor_version < static_cast<uint8_t>(v)))
     {
       LOG_PRINT_L1("Block with id: " << blk_hash << ", has invalid version " << static_cast<int>(blk.major_version) << "." << +blk.minor_version <<
               "; current: " << static_cast<int>(v) << "." << static_cast<int>(v) << " for height " << blk_height);
@@ -4193,8 +4194,9 @@ bool Blockchain::basic_block_checks(cryptonote::block const &blk, bool alt_block
       }
     }
 
-    // HF19 TODO: remove the requirement that minor_version must be >= network version
-    if (blk.major_version != required_major_version || blk.minor_version < static_cast<uint8_t>(required_major_version))
+    // HF19 TODO: after hardfork 19 occurs we can remove the second line of this test:
+    if (blk.major_version != required_major_version ||
+            (blk.major_version < hf::hf19 && blk.minor_version < static_cast<uint8_t>(required_major_version)))
     {
       MGINFO_RED("Block with id: " << blk_hash << ", has invalid version " << static_cast<int>(blk.major_version) << "." << +blk.minor_version <<
               "; current: " << static_cast<int>(required_major_version) << "." << static_cast<int>(required_major_version) << " for height " << blk_height);


### PR DESCRIPTION
Monero perverted the minor version many forks ago; this returns it to being a minor version, making the blocks reflect our actual minor version.