### PR TITLE
Remove use of deprecated ftime

### DIFF
--- a/src/crypto/oaes_lib.c
+++ b/src/crypto/oaes_lib.c
@@ -39,13 +39,7 @@
  #include <malloc.h>
 #endif
 
-// ANDROID, FreeBSD, OpenBSD and NetBSD also don't need timeb.h
-#if !defined(__FreeBSD__) && !defined(__OpenBSD__) && !defined(__ANDROID__) \
-  && !defined(__NetBSD__)
- #include <sys/timeb.h>
-#else
- #include <sys/time.h>
-#endif
+#include <sys/time.h>
 
 #ifdef WIN32
 #include <process.h>
@@ -474,19 +468,6 @@ OAES_RET oaes_sprintf(
 #ifdef OAES_HAVE_ISAAC
 static void oaes_get_seed( char buf[RANDSIZ + 1] )
 {
-        #if !defined(__FreeBSD__) && !defined(__OpenBSD__) && !defined(__NetBSD__)
-	struct timeb timer;
-	struct tm *gmTimer;
-	char * _test = NULL;
-	
-	ftime (&timer);
-	gmTimer = gmtime( &timer.time );
-	_test = (char *) calloc( sizeof( char ), timer.millitm );
-	sprintf( buf, "%04d%02d%02d%02d%02d%02d%03d%p%d",
-		gmTimer->tm_year + 1900, gmTimer->tm_mon + 1, gmTimer->tm_mday,
-		gmTimer->tm_hour, gmTimer->tm_min, gmTimer->tm_sec, timer.millitm,
-		_test + timer.millitm, GETPID() );
-	#else
 	struct timeval timer;
 	struct tm *gmTimer;
 	char * _test = NULL;
@@ -498,7 +479,6 @@ static void oaes_get_seed( char buf[RANDSIZ + 1] )
 		gmTimer->tm_year + 1900, gmTimer->tm_mon + 1, gmTimer->tm_mday,
 		gmTimer->tm_hour, gmTimer->tm_min, gmTimer->tm_sec, timer.tv_usec/1000,
 		_test + timer.tv_usec/1000, GETPID() );
-	#endif
 		
 	if( _test )
 		free( _test );
@@ -506,19 +486,6 @@ static void oaes_get_seed( char buf[RANDSIZ + 1] )
 #else
 static uint32_t oaes_get_seed(void)
 {
-        #if !defined(__FreeBSD__) && !defined(__OpenBSD__) && !defined(__ANDROID__) && !defined(__NetBSD__)
-	struct timeb timer;
-	struct tm *gmTimer;
-	char * _test = NULL;
-	uint32_t _ret = 0;
-	
-	ftime (&timer);
-	gmTimer = gmtime( &timer.time );
-	_test = (char *) calloc( sizeof( char ), timer.millitm );
-	_ret = gmTimer->tm_year + 1900 + gmTimer->tm_mon + 1 + gmTimer->tm_mday +
-			gmTimer->tm_hour + gmTimer->tm_min + gmTimer->tm_sec + timer.millitm +
-			(uintptr_t) ( _test + timer.millitm ) + GETPID();
-	#else
 	struct timeval timer;
 	struct tm *gmTimer;
 	char * _test = NULL;
@@ -530,7 +497,6 @@ static uint32_t oaes_get_seed(void)
 	_ret = gmTimer->tm_year + 1900 + gmTimer->tm_mon + 1 + gmTimer->tm_mday +
 			gmTimer->tm_hour + gmTimer->tm_min + gmTimer->tm_sec + timer.tv_usec/1000 +
 			(uintptr_t) ( _test + timer.tv_usec/1000 ) + GETPID();
-	#endif
 
 	if( _test )
 		free( _test );


### PR DESCRIPTION
Remove ftime-is-deprecated warnings.  The alternative code was already here, but for some reason the deprecated version was being used on non-BSD platforms.