### PR TITLE
Speed up test_variant2_int_sqrt tests by skipping most values

### DIFF
--- a/tests/hash/main.cpp
+++ b/tests/hash/main.cpp
@@ -283,7 +283,11 @@ int test_variant2_int_sqrt()
     return 1;
   }
 
-  for (uint64_t i = 1; i <= 3558067407UL; ++i) {
+  const char* full = std::getenv("V2_INT_SQRT_FULL_TEST");
+  const uint64_t incr = full && full == "1"sv
+      ? 1 : 83;
+
+  for (uint64_t i = 1; i <= 3558067407UL; i += incr) {
     // "i" is integer part of "sqrt(2^64 + n) * 2 - 2^33"
     // n = (i/2 + 2^32)^2 - 2^64
 


### PR DESCRIPTION
This test uses 3.5 billion iterations, and takes multiple minutes --
effectively just as long as all other test suite tests combined.

This is dumb.

Reduce the "optimized" version to increment by 83 instead of 1, the same
as the "reference" version, but add a V2_INT_SQRT_FULL_TEST=1
environment variable you can set if you really want to test your CPU
cooler.