### PR TITLE
Next height is now

### DIFF
--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -207,7 +207,7 @@ namespace cryptonote {
       if (cryptonote::is_valid_address(address, m_nettype)) {
         cryptonote::address_parse_info addr_info {};
         cryptonote::get_account_address_from_str(addr_info, m_nettype, address);
-        uint64_t next_payout_height = addr_info.address.next_payout_height(block_height - 1, conf.BATCHING_INTERVAL);
+        uint64_t next_payout_height = addr_info.address.next_payout_height(block_height, conf.BATCHING_INTERVAL);
         if (block_height == next_payout_height) {
           payments.emplace_back(
               std::move(address),

--- a/src/cryptonote_basic/cryptonote_basic.cpp
+++ b/src/cryptonote_basic/cryptonote_basic.cpp
@@ -152,7 +152,7 @@ uint64_t account_public_address::next_payout_height(uint64_t current_height, uin
 {
   auto pay_offset = modulus(interval);
   auto curr_offset = current_height % interval;
-  if (pay_offset <= curr_offset)
+  if (pay_offset < curr_offset)
     pay_offset += interval;
   return current_height + pay_offset - curr_offset;
 }

--- a/src/cryptonote_basic/cryptonote_basic.cpp
+++ b/src/cryptonote_basic/cryptonote_basic.cpp
@@ -150,10 +150,11 @@ uint64_t account_public_address::modulus(uint64_t interval) const
 
 uint64_t account_public_address::next_payout_height(uint64_t current_height, uint64_t interval) const
 {
-  uint64_t next_payout_height = current_height + (modulus(interval) - current_height % interval);
-  if (next_payout_height <= current_height)
-    next_payout_height += interval;
-  return next_payout_height;
+  auto pay_offset = modulus(interval);
+  auto curr_offset = current_height % interval;
+  if (pay_offset <= curr_offset)
+    pay_offset += interval;
+  return current_height + pay_offset - curr_offset;
 }
 
 }


### PR DESCRIPTION
Tweak next_payout_height:

- Avoid use of integer overflow in `next_payout_height`.  It wasn't technically wrong, but using overflow is a bit icky and it's easy enough to calculate it without overflow.
- Make `next_payout_height` return the height >= current height, rather than strictly `>`.  (This is what callers of this function want, avoids needing to pass in height-1 from db_sqlite.cpp, and fixes a wallet bug that jumps the payout height one block too early).