### PR TITLE
Make sure we have sqlite 3.24.0+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -480,7 +480,7 @@ endif()
 
 if(NOT BUILD_STATIC_DEPS)
   find_package(PkgConfig REQUIRED)
-  pkg_check_modules(SQLITE3 REQUIRED sqlite3 IMPORTED_TARGET GLOBAL)
+  pkg_check_modules(SQLITE3 REQUIRED sqlite3>=3.24.0 IMPORTED_TARGET GLOBAL)
   message(STATUS "Found sqlite3 ${SQLITE3_VERSION}")
   add_library(SQLite::SQLite3 ALIAS PkgConfig::SQLITE3)
 endif()

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ library archives (`.a`).
 | pkg-config   | any           | NO       | `pkg-config`           | `base-devel` | `pkgconf`           | NO       |                  |
 | Boost        | 1.65          | NO       | `libboost-all-dev`[2]  | `boost`      | `boost-devel`       | NO       | C++ libraries    |
 | libzmq       | 4.3.0         | YES      | `libzmq3-dev`          | `zeromq`     | `zeromq-devel`      | NO       | ZeroMQ library   |
-| sqlite3      | ?             | YES      | `libsqlite3-dev`       | `sqlite`     | `sqlite-devel`      | NO       | Oxen Name System |
+| sqlite3      | 3.24.0        | YES      | `libsqlite3-dev`       | `sqlite`     | `sqlite-devel`      | NO       | ONS, batching    |
 | libsodium    | 1.0.9         | YES      | `libsodium-dev`        | `libsodium`  | `libsodium-devel`   | NO       | cryptography     |
 | libcurl      | 4.0           | NO       | `libcurl4-dev`         | `curl`       | `curl-devel`        | NO       | HTTP RPC         |
 | libuv (Win)  | any           | NO       | (Windows only)         | --           | --                  | NO       | RPC event loop   |


### PR DESCRIPTION
Batching code relies on UPSERTs which were added in 3.24.

This broke initial bionic debs, which needed a sqlite3 backport from newer Ubuntu to address, as well as people compiling from source on systems with older sqlite3.