### PR TITLE
Keep SNL state correct during resyncing of sqlite submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ message(STATUS "CMake version ${CMAKE_VERSION}")
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.12 CACHE STRING "macOS deployment target (Apple clang only)")
 
 project(oxen
-    VERSION 10.1.1
+    VERSION 10.1.2
     LANGUAGES CXX C)
 set(OXEN_RELEASE_CODENAME "Wistful Wagyu")
 

--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -131,7 +131,7 @@ namespace cryptonote {
     }
 
     if (!have_offset) {
-      MGINFO("Adding payout_offset to batching db");
+      MINFO("Adding payout_offset to batching db");
       auto& netconf = get_config(m_nettype);
       SQLite::Transaction transaction{
         db,

--- a/src/blockchain_db/sqlite/db_sqlite.h
+++ b/src/blockchain_db/sqlite/db_sqlite.h
@@ -51,6 +51,7 @@ public:
 
   // Database management functions. Should be called on creation of BlockchainSQLite
   void create_schema();
+  void upgrade_schema();
   void reset_database();
 
   // The batching database maintains a height variable to know if it gets out of sync with the mainchain. Calling increment and decrement is the primary method of interacting with this height variable

--- a/src/blockchain_db/sqlite/db_sqlite.h
+++ b/src/blockchain_db/sqlite/db_sqlite.h
@@ -70,6 +70,11 @@ private:
       const service_nodes::service_node_list::state_t& service_nodes_state,
       bool add);
 
+  std::unordered_map<account_public_address, std::string> address_str_cache;
+  std::pair<hf, cryptonote::address_parse_info> parsed_governance_addr = {hf::none, {}};
+  const std::string& get_address_str(const account_public_address& addr);
+  std::mutex address_str_cache_mutex;
+
 public:
 
   // get_accrued_earnings -> queries the database for the amount that has been accrued to `service_node_address` will return the atomic value in oxen that

--- a/src/blockchain_db/sqlite/db_sqlite.h
+++ b/src/blockchain_db/sqlite/db_sqlite.h
@@ -89,11 +89,12 @@ public:
 
   // calculate_rewards -> takes the list of contributors from sn_info with their SN contribution
   // amounts and will calculate how much of the block rewards should be the allocated to the
-  // contributors. The function will return a list suitable for passing to add_sn_payments
+  // contributors. The function will set a list suitable for passing to add_sn_payments into the
+  // vector (any existing values will be cleared).
   //
   // Note that distribution_amount here is typically passed as milli-atomic OXEN for extra
   // precision.
-  std::vector<cryptonote::batch_sn_payment> calculate_rewards(hf hf_version, uint64_t distribution_amount, service_nodes::service_node_info sn_info);
+  void calculate_rewards(hf hf_version, uint64_t distribution_amount, const service_nodes::service_node_info& sn_info, std::vector<cryptonote::batch_sn_payment>& rewards);
 
   // add/pop_block -> takes a block that contains new block rewards to be batched and added to the database
   // and/or batching payments that need to be subtracted from the database, in addition it takes a reference to

--- a/src/crypto/keccak.c
+++ b/src/crypto/keccak.c
@@ -110,7 +110,7 @@ void keccak(const uint8_t *in, size_t inlen, uint8_t *md, int mdlen)
       for (i = 0; i < rsizw; i++) {
         uint64_t ina;
         memcpy(&ina, in + i * 8, 8);
-        st[i] ^= swap64le(ina);
+        st[i] ^= SWAP64LE(ina);
       }
       keccakf(st, KECCAK_ROUNDS);
     }
@@ -128,7 +128,7 @@ void keccak(const uint8_t *in, size_t inlen, uint8_t *md, int mdlen)
     temp[rsiz - 1] |= 0x80;
 
     for (i = 0; i < rsizw; i++)
-        st[i] ^= swap64le(((uint64_t *) temp)[i]);
+        st[i] ^= SWAP64LE(((uint64_t *) temp)[i]);
 
     keccakf(st, KECCAK_ROUNDS);
 
@@ -151,7 +151,7 @@ void keccak1600(const uint8_t *in, size_t inlen, uint8_t *md)
 #define IS_ALIGNED_64(p) (0 == (7 & ((const char*)(p) - (const char*)0)))
 #define KECCAK_PROCESS_BLOCK(st, block) { \
     for (int i_ = 0; i_ < KECCAK_WORDS; i_++){ \
-        ((st))[i_] ^= swap64le(((block))[i_]); \
+        ((st))[i_] ^= SWAP64LE(((block))[i_]); \
     }; \
     keccakf(st, KECCAK_ROUNDS); }
 

--- a/src/cryptonote_basic/cryptonote_basic_impl.cpp
+++ b/src/cryptonote_basic/cryptonote_basic_impl.cpp
@@ -159,17 +159,6 @@ namespace cryptonote {
     return true;
   }
   //------------------------------------------------------------------------------------
-  batch_sn_payment::batch_sn_payment(std::string addr, uint64_t amt, cryptonote::network_type nettype):address(addr),amount(amt){
-    cryptonote::get_account_address_from_str(address_info, nettype, address);
-  };
-  batch_sn_payment::batch_sn_payment(cryptonote::address_parse_info& addr_info, uint64_t amt, cryptonote::network_type nettype):address_info(addr_info),amount(amt){
-    address = cryptonote::get_account_address_as_str(nettype, address_info.is_subaddress, address_info.address);
-  };
-  batch_sn_payment::batch_sn_payment(const cryptonote::account_public_address& addr, uint64_t amt, cryptonote::network_type nettype):amount(amt){
-    address_info = cryptonote::address_parse_info{addr,0};
-    address = cryptonote::get_account_address_as_str(nettype, address_info.is_subaddress, address_info.address);
-  };
-  //------------------------------------------------------------------------------------
   uint8_t get_account_address_checksum(const public_address_outer_blob& bl)
   {
     const unsigned char* pbuf = reinterpret_cast<const unsigned char*>(&bl);

--- a/src/cryptonote_basic/cryptonote_basic_impl.h
+++ b/src/cryptonote_basic/cryptonote_basic_impl.h
@@ -67,13 +67,13 @@ namespace cryptonote {
   };
 
   struct batch_sn_payment {
-    std::string address;
     cryptonote::address_parse_info address_info;
     uint64_t amount;
     batch_sn_payment() = default;
-    batch_sn_payment(std::string addr, uint64_t amt, cryptonote::network_type nettype);
-    batch_sn_payment(cryptonote::address_parse_info& addr_info, uint64_t amt, cryptonote::network_type nettype);
-    batch_sn_payment(const cryptonote::account_public_address& addr, uint64_t amt, cryptonote::network_type nettype);
+    batch_sn_payment(const cryptonote::address_parse_info& addr_info, uint64_t amt)
+        : address_info{addr_info}, amount{amt} {}
+    batch_sn_payment(const cryptonote::account_public_address& addr, uint64_t amt)
+        : address_info{addr, 0}, amount{amt} {}
   };
 
   class ValidateMinerTxHook

--- a/src/cryptonote_basic/difficulty.cpp
+++ b/src/cryptonote_basic/difficulty.cpp
@@ -47,52 +47,6 @@ namespace cryptonote {
   using std::uint64_t;
   using std::vector;
 
-#if defined(__x86_64__)
-  static inline void mul(uint64_t a, uint64_t b, uint64_t &low, uint64_t &high) {
-    low = mul128(a, b, &high);
-  }
-
-#else
-
-  static inline void mul(uint64_t a, uint64_t b, uint64_t &low, uint64_t &high) {
-    // __int128 isn't part of the standard, so the previous function wasn't portable. mul128() in Windows is fine,
-    // but this portable function should be used elsewhere. Credit for this function goes to latexi95.
-
-    uint64_t aLow = a & 0xFFFFFFFF;
-    uint64_t aHigh = a >> 32;
-    uint64_t bLow = b & 0xFFFFFFFF;
-    uint64_t bHigh = b >> 32;
-
-    uint64_t res = aLow * bLow;
-    uint64_t lowRes1 = res & 0xFFFFFFFF;
-    uint64_t carry = res >> 32;
-
-    res = aHigh * bLow + carry;
-    uint64_t highResHigh1 = res >> 32;
-    uint64_t highResLow1 = res & 0xFFFFFFFF;
-
-    res = aLow * bHigh;
-    uint64_t lowRes2 = res & 0xFFFFFFFF;
-    carry = res >> 32;
-
-    res = aHigh * bHigh + carry;
-    uint64_t highResHigh2 = res >> 32;
-    uint64_t highResLow2 = res & 0xFFFFFFFF;
-
-    //Addition
-
-    uint64_t r = highResLow1 + lowRes2;
-    carry = r >> 32;
-    low = (r << 32) | lowRes1;
-    r = highResHigh1 + highResLow2 + carry;
-    uint64_t d3 = r & 0xFFFFFFFF;
-    carry = r >> 32;
-    r = highResHigh2 + carry;
-    high = d3 | (r << 32);
-  }
-
-#endif
-
   static inline bool cadd(uint64_t a, uint64_t b) {
     return a + b < a;
   }
@@ -104,15 +58,15 @@ namespace cryptonote {
   bool check_hash(const crypto::hash &hash, difficulty_type difficulty) {
     uint64_t low, high, top, cur;
     // First check the highest word, this will most likely fail for a random hash.
-    mul(swap64le(((const uint64_t *) &hash)[3]), difficulty, top, high);
+    top = mul128(SWAP64LE(((const uint64_t *) &hash)[3]), difficulty, &high);
     if (high != 0) {
       return false;
     }
-    mul(swap64le(((const uint64_t *) &hash)[0]), difficulty, low, cur);
-    mul(swap64le(((const uint64_t *) &hash)[1]), difficulty, low, high);
+    low = mul128(SWAP64LE(((const uint64_t *) &hash)[0]), difficulty, &cur);
+    low = mul128(SWAP64LE(((const uint64_t *) &hash)[1]), difficulty, &high);
     bool carry = cadd(cur, low);
     cur = high;
-    mul(swap64le(((const uint64_t *) &hash)[2]), difficulty, low, high);
+    low = mul128(SWAP64LE(((const uint64_t *) &hash)[2]), difficulty, &high);
     carry = cadc(cur, low, carry);
     carry = cadc(high, top, carry);
     return !carry;

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -358,7 +358,7 @@ namespace cryptonote
 
         if (hard_fork_version >= hf::hf19_reward_batching) {
           for (size_t i = 0; i < p_payouts.size(); i++)
-            batched_rewards.emplace_back(p_payouts[i].address, split_rewards[i], nettype);
+            batched_rewards.emplace_back(p_payouts[i].address, split_rewards[i]);
         } else {
           for (size_t i = 0; i < p_payouts.size(); i++)
             rewards.push_back({reward_type::snode, p_payouts[i].address, split_rewards[i]});
@@ -369,7 +369,7 @@ namespace cryptonote
       if (hard_fork_version >= hf::hf19_reward_batching)
       {
         for (size_t i = 0; i < leader.payouts.size(); i++)
-          batched_rewards.emplace_back(leader.payouts[i].address, split_rewards[i], nettype);
+          batched_rewards.emplace_back(leader.payouts[i].address, split_rewards[i]);
       }
       else
       {
@@ -386,7 +386,7 @@ namespace cryptonote
       if (uint64_t miner_amount = reward_parts.base_miner + reward_parts.miner_fee; miner_amount)
       {
         if (hard_fork_version >= hf::hf19_reward_batching) {
-          batched_rewards.emplace_back(miner_tx_context.miner_block_producer, miner_amount, nettype);
+          batched_rewards.emplace_back(miner_tx_context.miner_block_producer, miner_amount);
         } else {
           rewards.push_back({reward_type::miner, miner_tx_context.miner_block_producer, miner_amount});
         }
@@ -399,7 +399,7 @@ namespace cryptonote
                                           hard_fork_version >= hf::hf16_pulse /*distribute_remainder*/);
         if (hard_fork_version >= hf::hf19_reward_batching) {
           for (size_t i = 0; i < leader.payouts.size(); i++)
-            batched_rewards.emplace_back(leader.payouts[i].address, split_rewards[i], nettype);
+            batched_rewards.emplace_back(leader.payouts[i].address, split_rewards[i]);
         } else {
           for (size_t i = 0; i < leader.payouts.size(); i++)
             rewards.push_back({reward_type::snode, leader.payouts[i].address, split_rewards[i]});

--- a/tests/blockchain_sqlite_test.h
+++ b/tests/blockchain_sqlite_test.h
@@ -15,8 +15,8 @@ public:
 
   BlockchainSQLiteTest(BlockchainSQLiteTest &other)
     : BlockchainSQLiteTest(other.m_nettype, check_if_copy_filename(other.filename)) {
-    auto all_payments_accrued = db::get_all<std::string, int64_t>(
-            other.prepared_st("SELECT address, amount FROM batched_payments_accrued"));
+    auto all_payments_accrued = db::get_all<std::string, int, int64_t>(
+            other.prepared_st("SELECT address, payout_offset, amount FROM batched_payments_accrued"));
     auto all_payments_paid = db::get_all<std::string, int64_t, int64_t>(
             other.prepared_st("SELECT address, amount, height_paid FROM batched_payments_raw"));
 
@@ -34,10 +34,10 @@ public:
     }
 
     auto insert_payment_accrued = prepared_st(
-      "INSERT INTO batched_payments_accrued (address, amount) VALUES (?, ?)");
+      "INSERT INTO batched_payments_accrued (address, payout_offset, amount) VALUES (?, ?, ?)");
 
-    for (auto& [address, amount]: all_payments_accrued) {
-      db::exec_query(insert_payment_accrued, address, amount);
+    for (auto& [address, offset, amount]: all_payments_accrued) {
+      db::exec_query(insert_payment_accrued, address, offset, amount);
       insert_payment_accrued->reset();
     }
 

--- a/tests/unit_tests/mul_div.cpp
+++ b/tests/unit_tests/mul_div.cpp
@@ -118,12 +118,10 @@ namespace
 
   TEST(div128_32, handles_zero)
   {
-    uint32_t reminder;
     uint64_t hi;
     uint64_t lo;
 
-    reminder = div128_32(0, 0, 7, &hi, &lo);
-    ASSERT_EQ(reminder, 0);
+    div128_32(0, 0, 7, &hi, &lo);
     ASSERT_EQ(hi, 0);
     ASSERT_EQ(lo, 0);
 
@@ -132,73 +130,60 @@ namespace
 
   TEST(div128_32, handles_one)
   {
-    uint32_t reminder;
     uint64_t hi;
     uint64_t lo;
 
-    reminder = div128_32(0, 7, 1, &hi, &lo);
-    ASSERT_EQ(reminder, 0);
+    div128_32(0, 7, 1, &hi, &lo);
     ASSERT_EQ(hi, 0);
     ASSERT_EQ(lo, 7);
 
-    reminder = div128_32(7, 0, 1, &hi, &lo);
-    ASSERT_EQ(reminder, 0);
+    div128_32(7, 0, 1, &hi, &lo);
     ASSERT_EQ(hi, 7);
     ASSERT_EQ(lo, 0);
   }
 
   TEST(div128_32, handles_if_dividend_less_divider)
   {
-    uint32_t reminder;
     uint64_t hi;
     uint64_t lo;
 
-    reminder = div128_32(0, 1383746, 1645825, &hi, &lo);
-    ASSERT_EQ(reminder, 1383746);
+    div128_32(0, 1383746, 1645825, &hi, &lo);
     ASSERT_EQ(hi, 0);
     ASSERT_EQ(lo, 0);
   }
 
   TEST(div128_32, handles_if_dividend_dwords_less_divider)
   {
-    uint32_t reminder;
     uint64_t hi;
     uint64_t lo;
 
-    reminder = div128_32(0x5AD629E441074F28, 0x0DBCAB2B231081F1, 0xFE735CD6, &hi, &lo);
-    ASSERT_EQ(reminder, 0xB9C924E9);
+    div128_32(0x5AD629E441074F28, 0x0DBCAB2B231081F1, 0xFE735CD6, &hi, &lo);
     ASSERT_EQ(hi, 0x000000005B63C274);
     ASSERT_EQ(lo, 0x9084FC024383E48C);
   }
 
   TEST(div128_32, works_correctly)
   {
-    uint32_t reminder;
     uint64_t hi;
     uint64_t lo;
 
-    reminder = div128_32(2, 0, 2, &hi, &lo);
-    ASSERT_EQ(reminder, 0);
+    div128_32(2, 0, 2, &hi, &lo);
     ASSERT_EQ(hi, 1);
     ASSERT_EQ(lo, 0);
 
-    reminder = div128_32(0xffffffffffffffff, 0, 0xffffffff, &hi, &lo);
-    ASSERT_EQ(reminder, 0);
+    div128_32(0xffffffffffffffff, 0, 0xffffffff, &hi, &lo);
     ASSERT_EQ(hi, 0x0000000100000001);
     ASSERT_EQ(lo, 0);
 
-    reminder = div128_32(0xffffffffffffffff, 5846, 0xffffffff, &hi, &lo);
-    ASSERT_EQ(reminder, 5846);
+    div128_32(0xffffffffffffffff, 5846, 0xffffffff, &hi, &lo);
     ASSERT_EQ(hi, 0x0000000100000001);
     ASSERT_EQ(lo, 0);
 
-    reminder = div128_32(0xffffffffffffffff - 1, 0, 0xffffffff, &hi, &lo);
-    ASSERT_EQ(reminder, 0xfffffffe);
+    div128_32(0xffffffffffffffff - 1, 0, 0xffffffff, &hi, &lo);
     ASSERT_EQ(hi, 0x0000000100000000);
     ASSERT_EQ(lo, 0xfffffffefffffffe);
 
-    reminder = div128_32(0x2649372534875028, 0xaedbfedc5adbc739, 0x27826534, &hi, &lo);
-    ASSERT_EQ(reminder, 0x1a6dc2e5);
+    div128_32(0x2649372534875028, 0xaedbfedc5adbc739, 0x27826534, &hi, &lo);
     ASSERT_EQ(hi, 0x00000000f812c1f8);
     ASSERT_EQ(lo, 0xddf2fdb09bc2e2e9);
   }

--- a/tests/unit_tests/sqlite.cpp
+++ b/tests/unit_tests/sqlite.cpp
@@ -56,7 +56,7 @@ TEST(SQLITE, AddSNRewards)
 
   cryptonote::get_account_address_from_str(wallet_address, cryptonote::network_type::FAKECHAIN, "LCFxT37LAogDn1jLQKf4y7aAqfi21DjovX9qyijaLYQSdrxY1U5VGcnMJMjWrD9RhjeK5Lym67wZ73uh9AujXLQ1RKmXEyL");
 
-  t1.emplace_back(wallet_address.address, 16500000001'789/2, cryptonote::network_type::FAKECHAIN);
+  t1.emplace_back(wallet_address.address, 16500000001'789/2);
 
   bool success = false;
   success = sqliteDB.add_sn_rewards(t1);
@@ -78,12 +78,12 @@ TEST(SQLITE, AddSNRewards)
 
   // Pay an amount less than the database expects and test for failure
   std::vector<cryptonote::batch_sn_payment> t2;
-  t2.emplace_back(wallet_address.address, expected_amount - 1000, cryptonote::network_type::FAKECHAIN);
+  t2.emplace_back(wallet_address.address, expected_amount - 1000);
   EXPECT_FALSE(sqliteDB.save_payments(expected_payout, t2));
 
   // Pay the amount back out and expect the database to be empty
   std::vector<cryptonote::batch_sn_payment> t3;
-  t3.emplace_back(wallet_address.address, expected_amount, cryptonote::network_type::FAKECHAIN);
+  t3.emplace_back(wallet_address.address, expected_amount);
   success = sqliteDB.save_payments(expected_payout, t3);
   EXPECT_TRUE(success);
   EXPECT_EQ(sqliteDB.batching_count(), 0);

--- a/tests/unit_tests/sqlite.cpp
+++ b/tests/unit_tests/sqlite.cpp
@@ -103,7 +103,8 @@ TEST(SQLITE, CalculateRewards)
   cryptonote::get_account_address_from_str(first_address, cryptonote::network_type::TESTNET, "T6TzkJb5EiASaCkcH7idBEi1HSrpSQJE1Zq3aL65ojBMPZvqHNYPTL56i3dncGVNEYCG5QG5zrBmRiVwcg6b1cRM1SRNqbp44");
   single_contributor.contributors.emplace_back(0, first_address.address);
   single_contributor.contributors.back().amount = block.reward;
-  auto rewards = sqliteDB.calculate_rewards(block.major_version, block.reward, single_contributor);
+  std::vector<cryptonote::batch_sn_payment> rewards;
+  sqliteDB.calculate_rewards(block.major_version, block.reward, single_contributor, rewards);
   auto hf_version = block.major_version;
 
   // Check that 3 contributor receives their portion of the block reward
@@ -118,25 +119,25 @@ TEST(SQLITE, CalculateRewards)
   cryptonote::get_account_address_from_str(third_address, cryptonote::network_type::TESTNET, "T6SkkovCyLWViVDMgeJoF7X4vFrHnKX5jXyktaoGmRuNTdoFEx1xXu1joXdmeH9mx2LLNPq998fKKcsAHwdRJWhk126SapptR");
   multiple_contributors.contributors.emplace_back(0, third_address.address);
   multiple_contributors.contributors.back().amount = 34;
-  auto multiple_rewards = sqliteDB.calculate_rewards(block.major_version, block.reward, multiple_contributors);
+  sqliteDB.calculate_rewards(block.major_version, block.reward, multiple_contributors, rewards);
 
-  EXPECT_EQ(multiple_rewards[0].amount, 66);
-  EXPECT_EQ(multiple_rewards[1].amount, 66);
-  EXPECT_EQ(multiple_rewards[2].amount, 68);
+  EXPECT_EQ(rewards[0].amount, 66);
+  EXPECT_EQ(rewards[1].amount, 66);
+  EXPECT_EQ(rewards[2].amount, 68);
 
   // Check that 3 contributors receives their portion of the block reward when the operator takes a 10% fee
   multiple_contributors.portions_for_operator = cryptonote::old::STAKING_PORTIONS/10;
   multiple_contributors.operator_address = first_address.address;
   block.reward = 1000;
-  auto multiple_rewards_with_fee = sqliteDB.calculate_rewards(block.major_version, block.reward, multiple_contributors);
+  sqliteDB.calculate_rewards(block.major_version, block.reward, multiple_contributors, rewards);
   // Operator gets 10%
-  EXPECT_EQ(multiple_rewards_with_fee[0].amount, 99);
-  EXPECT_EQ(tools::view_guts(multiple_rewards_with_fee[0].address_info.address), tools::view_guts(first_address.address));
+  EXPECT_EQ(rewards[0].amount, 99);
+  EXPECT_EQ(tools::view_guts(rewards[0].address_info.address), tools::view_guts(first_address.address));
   // Contributors (including operator) receive the balance
-  EXPECT_EQ(multiple_rewards_with_fee[1].amount, 297);
-  EXPECT_EQ(tools::view_guts(multiple_rewards_with_fee[1].address_info.address), tools::view_guts(first_address.address));
-  EXPECT_EQ(multiple_rewards_with_fee[2].amount, 297);
-  EXPECT_EQ(tools::view_guts(multiple_rewards_with_fee[2].address_info.address), tools::view_guts(second_address.address));
-  EXPECT_EQ(multiple_rewards_with_fee[3].amount, 306);
-  EXPECT_EQ(tools::view_guts(multiple_rewards_with_fee[3].address_info.address), tools::view_guts(third_address.address));
+  EXPECT_EQ(rewards[1].amount, 297);
+  EXPECT_EQ(tools::view_guts(rewards[1].address_info.address), tools::view_guts(first_address.address));
+  EXPECT_EQ(rewards[2].amount, 297);
+  EXPECT_EQ(tools::view_guts(rewards[2].address_info.address), tools::view_guts(second_address.address));
+  EXPECT_EQ(rewards[3].amount, 306);
+  EXPECT_EQ(tools::view_guts(rewards[3].address_info.address), tools::view_guts(third_address.address));
 }


### PR DESCRIPTION
When the sqlite batching database is resyncing it is dependant on the
service node list state being correct at the time the block is added to
the batching database. When syncing a singular module this sometimes is
not the case as the service node list state may be ahead or behind. This
patch simply ensures that when the batching database is behind the
service node list is reset back to that point in time.