### PR TITLE
Fix negative coinbase emissions

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1705,13 +1705,13 @@ namespace cryptonote
     return m_mempool.check_for_key_images(key_im, spent);
   }
   //-----------------------------------------------------------------------------------------------
-  std::optional<std::tuple<uint64_t, uint64_t, uint64_t>> core::get_coinbase_tx_sum(uint64_t start_offset, size_t count)
+  std::optional<std::tuple<int64_t, int64_t, int64_t>> core::get_coinbase_tx_sum(uint64_t start_offset, size_t count)
   {
-    std::tuple<uint64_t, uint64_t, uint64_t> result{0, 0, 0};
+    std::optional<std::tuple<int64_t, int64_t, int64_t>> result{{0, 0, 0}};
     if (count == 0)
       return result;
 
-    auto& [emission_amount, total_fee_amount, burnt_oxen] = result;
+    auto& [emission_amount, total_fee_amount, burnt_oxen] = *result;
 
     // Caching.
     //
@@ -1782,18 +1782,18 @@ namespace cryptonote
     const uint64_t end = start_offset + count - 1;
     m_blockchain_storage.for_blocks_range(start_offset, end,
       [this, &cache_to, &result, &cache_build_started](uint64_t height, const crypto::hash& hash, const block& b){
-      auto& [emission_amount, total_fee_amount, burnt_oxen] = result;
+      auto& [emission_amount, total_fee_amount, burnt_oxen] = *result;
       std::vector<transaction> txs;
       std::vector<crypto::hash> missed_txs;
-      uint64_t coinbase_amount = get_outs_money_amount(b.miner_tx);
+      auto coinbase_amount = static_cast<int64_t>(get_outs_money_amount(b.miner_tx));
       get_transactions(b.tx_hashes, txs, missed_txs);
-      uint64_t tx_fee_amount = 0;
+      int64_t tx_fee_amount = 0;
       for(const auto& tx: txs)
       {
-        tx_fee_amount += get_tx_miner_fee(tx, b.major_version >= feature::FEE_BURNING);
+        tx_fee_amount += static_cast<int64_t>(get_tx_miner_fee(tx, b.major_version >= feature::FEE_BURNING));
         if(b.major_version >= feature::FEE_BURNING)
         {
-          burnt_oxen += get_burned_amount_from_tx_extra(tx.extra);
+          burnt_oxen += static_cast<int64_t>(get_burned_amount_from_tx_extra(tx.extra));
         }
       }
 

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -798,7 +798,7 @@ namespace cryptonote
       * requested range.  The optional value will be empty only if requesting the full chain *and*
       * another thread is already calculating it.
       */
-     std::optional<std::tuple<uint64_t, uint64_t, uint64_t>> get_coinbase_tx_sum(uint64_t start_offset, size_t count);
+     std::optional<std::tuple<int64_t, int64_t, int64_t>> get_coinbase_tx_sum(uint64_t start_offset, size_t count);
 
      /**
       * @brief get the network type we're on
@@ -1212,7 +1212,8 @@ namespace cryptonote
      struct {
        std::shared_mutex mutex;
        bool building = false;
-       uint64_t height = 0, emissions = 0, fees = 0, burnt = 0;
+       uint64_t height = 0;
+       int64_t emissions = 0, fees = 0, burnt = 0;
      } m_coinbase_cache;
 
      std::optional<oxenmq::TaggedThreadID> m_pulse_thread_id;

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -1620,9 +1620,9 @@ namespace rpc {
     struct response
     {
       std::string status;       // General RPC error code. "OK" means everything looks good.
-      uint64_t emission_amount; // Amount of coinbase reward in atomic units.
-      uint64_t fee_amount;      // Amount of fees in atomic units.
-      uint64_t burn_amount;      // Amount of burnt oxen.
+      int64_t emission_amount; // Amount of coinbase reward in atomic units.
+      int64_t fee_amount;      // Amount of fees in atomic units.
+      int64_t burn_amount;      // Amount of burnt oxen.
 
       KV_MAP_SERIALIZABLE
     };


### PR DESCRIPTION
With batching, individual blocks can have a negative coinbase emission because the tx fee gets added to the batch rewards database and not paid out immediately, which then results in an negative overflow to a value close to 2^64.  Thus a block with no payout and a tx fee will have an erroneous huge positive coinbase emission when queried via `get_coinbase_tx_sum`.  For example block 1094068 queried with:

```json
{"jsonrpc":"2.0","id":"0","method":"get_coinbase_tx_sum","params":{"height": 1094068, "count": 1}}
```
returns:
```json
{
  "jsonrpc": "2.0",
  "id": "0",
  "result": {
    "burn_amount": 0,
    "emission_amount": 18446744073699378616,
    "fee_amount": 10173000,
    "status": "OK"
  }
}
```
This commit fixes it by making the values signed (and also serves as an example of why unsigned integers are usually the wrong choice):
```json
{
  "jsonrpc": "2.0",
  "id": "0",
  "result": {
    "burn_amount": 0,
    "emission_amount": -10173000,
    "fee_amount": 10173000,
    "status": "OK"
  }
}
```