### PR TITLE
Fix stringop-overflow error when building with gcc 12.x.

### DIFF
--- a/src/crypto/oaes_lib.c
+++ b/src/crypto/oaes_lib.c
@@ -1272,8 +1272,10 @@ OAES_RET oaes_encrypt( OAES_CTX * ctx,
 		memcpy( _block, c + 2 * OAES_BLOCK_SIZE + _i, _block_size );
 		
 		// insert pad
-		for( _j = 0; _j < OAES_BLOCK_SIZE - _block_size; _j++ )
-			_block[ _block_size + _j ] = _j + 1;
+		for( _j = 0; _j < OAES_BLOCK_SIZE - _block_size; _j++ ) {
+			uint8_t offset = _block_size + _j;
+			_block[ offset ] = _j + 1;
+		}
 	
 		// CBC
 		if( _ctx->options & OAES_OPTION_CBC )


### PR DESCRIPTION
Fixes #1577, this time actually fixing the problem, and without mangling the whitespace. Ahem.