### PR TITLE
Avoid failure if the trigger doesn't exist

### DIFF
--- a/src/blockchain_db/sqlite/db_sqlite.cpp
+++ b/src/blockchain_db/sqlite/db_sqlite.cpp
@@ -143,7 +143,7 @@ namespace cryptonote {
 
         CREATE INDEX batched_payments_accrued_payout_offset_idx ON batched_payments_accrued(payout_offset);
 
-        DROP TRIGGER rollback_payment;
+        DROP TRIGGER IF EXISTS rollback_payment;
         CREATE TRIGGER rollback_payment INSTEAD OF DELETE ON batched_payments_paid
         FOR EACH ROW BEGIN
             DELETE FROM batched_payments_raw WHERE address = OLD.address AND height_paid = OLD.height_paid;


### PR DESCRIPTION
I'm not entirely sure how this happens, but I came across a node that
was failing here because the trigger didn't exist -- possibly from a
partial upgrade?

In any case, the `IF EXISTS` makes it more lenient.