### PR TITLE
Fix block notify race condition, and drain some of the swamp

### DIFF
--- a/src/checkpoints/checkpoints.cpp
+++ b/src/checkpoints/checkpoints.cpp
@@ -167,7 +167,7 @@ namespace cryptonote
     return result;
   }
   //---------------------------------------------------------------------------
-  void checkpoints::block_added(const block_added_info& info)
+  void checkpoints::block_add(const block_add_info& info)
   {
     uint64_t const height = get_block_height(info.block);
     if (height < service_nodes::CHECKPOINT_STORE_PERSISTENTLY_INTERVAL || info.block.major_version < hf::hf12_checkpointing)

--- a/src/checkpoints/checkpoints.cpp
+++ b/src/checkpoints/checkpoints.cpp
@@ -167,10 +167,10 @@ namespace cryptonote
     return result;
   }
   //---------------------------------------------------------------------------
-  bool checkpoints::block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs, checkpoint_t const *checkpoint)
+  bool checkpoints::block_added(const block_added_info& info)
   {
-    uint64_t const height = get_block_height(block);
-    if (height < service_nodes::CHECKPOINT_STORE_PERSISTENTLY_INTERVAL || block.major_version < hf::hf12_checkpointing)
+    uint64_t const height = get_block_height(info.block);
+    if (height < service_nodes::CHECKPOINT_STORE_PERSISTENTLY_INTERVAL || info.block.major_version < hf::hf12_checkpointing)
       return true;
 
     uint64_t end_cull_height = 0;
@@ -203,13 +203,13 @@ namespace cryptonote
       }
     }
 
-    if (checkpoint)
-        update_checkpoint(*checkpoint);
+    if (info.checkpoint)
+        update_checkpoint(*info.checkpoint);
 
     return true;
   }
   //---------------------------------------------------------------------------
-  void checkpoints::blockchain_detached(uint64_t height, bool /*by_pop_blocks*/)
+  void checkpoints::blockchain_detached(uint64_t height)
   {
     m_last_cull_height = std::min(m_last_cull_height, height);
 

--- a/src/checkpoints/checkpoints.cpp
+++ b/src/checkpoints/checkpoints.cpp
@@ -167,11 +167,11 @@ namespace cryptonote
     return result;
   }
   //---------------------------------------------------------------------------
-  bool checkpoints::block_added(const block_added_info& info)
+  void checkpoints::block_added(const block_added_info& info)
   {
     uint64_t const height = get_block_height(info.block);
     if (height < service_nodes::CHECKPOINT_STORE_PERSISTENTLY_INTERVAL || info.block.major_version < hf::hf12_checkpointing)
-      return true;
+      return;
 
     uint64_t end_cull_height = 0;
     {
@@ -205,8 +205,6 @@ namespace cryptonote
 
     if (info.checkpoint)
         update_checkpoint(*info.checkpoint);
-
-    return true;
   }
   //---------------------------------------------------------------------------
   void checkpoints::blockchain_detached(uint64_t height)

--- a/src/checkpoints/checkpoints.h
+++ b/src/checkpoints/checkpoints.h
@@ -113,7 +113,7 @@ namespace cryptonote
   class checkpoints
   {
   public:
-    void block_added(const block_added_info& info);
+    void block_add(const block_add_info& info);
     void blockchain_detached(uint64_t height);
 
     bool get_checkpoint(uint64_t height, checkpoint_t &checkpoint) const;

--- a/src/checkpoints/checkpoints.h
+++ b/src/checkpoints/checkpoints.h
@@ -111,12 +111,10 @@ namespace cryptonote
    * either from a json file or via DNS from a checkpoint-hosting server.
    */
   class checkpoints
-    : public cryptonote::BlockAddedHook,
-      public cryptonote::BlockchainDetachedHook
   {
   public:
-    bool block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs, checkpoint_t const *checkpoint) override;
-    void blockchain_detached(uint64_t height, bool by_pop_blocks) override;
+    bool block_added(const block_added_info& info);
+    void blockchain_detached(uint64_t height);
 
     bool get_checkpoint(uint64_t height, checkpoint_t &checkpoint) const;
     /**

--- a/src/checkpoints/checkpoints.h
+++ b/src/checkpoints/checkpoints.h
@@ -113,7 +113,7 @@ namespace cryptonote
   class checkpoints
   {
   public:
-    bool block_added(const block_added_info& info);
+    void block_added(const block_added_info& info);
     void blockchain_detached(uint64_t height);
 
     bool get_checkpoint(uint64_t height, checkpoint_t &checkpoint) const;

--- a/src/cryptonote_basic/cryptonote_basic_impl.h
+++ b/src/cryptonote_basic/cryptonote_basic_impl.h
@@ -43,6 +43,12 @@ namespace cryptonote {
     const checkpoint_t* const checkpoint;
   };
   using BlockAddHook = std::function<void(const block_add_info& info)>;
+  struct block_post_add_info {
+    const cryptonote::block& block;
+    bool reorg;
+    uint64_t split_height; // Only set when reorg is true
+  };
+  using BlockPostAddHook = std::function<void(const block_post_add_info& info)>;
   struct detached_info {
     uint64_t height;
     bool by_pop_blocks;

--- a/src/cryptonote_basic/cryptonote_basic_impl.h
+++ b/src/cryptonote_basic/cryptonote_basic_impl.h
@@ -37,12 +37,12 @@
 
 namespace cryptonote {
   struct checkpoint_t;
-  struct block_added_info {
+  struct block_add_info {
     const cryptonote::block& block;
     const std::vector<transaction>& txs;
     const checkpoint_t* const checkpoint;
   };
-  using BlockAddedHook = std::function<void(const block_added_info& info)>;
+  using BlockAddHook = std::function<void(const block_add_info& info)>;
   struct detached_info {
     uint64_t height;
     bool by_pop_blocks;

--- a/src/cryptonote_basic/cryptonote_basic_impl.h
+++ b/src/cryptonote_basic/cryptonote_basic_impl.h
@@ -36,23 +36,27 @@
 
 
 namespace cryptonote {
-  class BlockAddedHook
-  {
-  public:
-    virtual bool block_added(const block& block, const std::vector<transaction>& txs, struct checkpoint_t const *checkpoint) = 0;
+  struct checkpoint_t;
+  struct block_added_info {
+    const cryptonote::block& block;
+    const std::vector<transaction>& txs;
+    const checkpoint_t* const checkpoint;
   };
-
-  class BlockchainDetachedHook
-  {
-  public:
-    virtual void blockchain_detached(uint64_t height, bool by_pop_blocks) = 0;
+  using BlockAddedHook = std::function<bool(const block_added_info& info)>;
+  struct detached_info {
+    uint64_t height;
+    bool by_pop_blocks;
   };
-
-  class InitHook
-  {
-  public:
-    virtual void init() = 0;
+  using BlockchainDetachedHook = std::function<void(const detached_info& info)>;
+  using InitHook = std::function<void()>;
+  struct batch_sn_payment;
+  struct block_reward_parts;
+  struct miner_tx_info {
+    const cryptonote::block& block;
+    const block_reward_parts& reward_parts;
+    const std::vector<cryptonote::batch_sn_payment>& batched_sn_payments;
   };
+  using ValidateMinerTxHook = std::function<bool(const miner_tx_info& info)>;
 
   struct address_parse_info
   {
@@ -74,18 +78,6 @@ namespace cryptonote {
         : address_info{addr_info}, amount{amt} {}
     batch_sn_payment(const cryptonote::account_public_address& addr, uint64_t amt)
         : address_info{addr, 0}, amount{amt} {}
-  };
-
-  class ValidateMinerTxHook
-  {
-  public:
-    virtual bool validate_miner_tx(cryptonote::block const &block, struct block_reward_parts const &reward_parts, std::optional<std::vector<cryptonote::batch_sn_payment>> const &batched_sn_payments) const = 0;
-  };
-
-  class AltBlockAddedHook
-  {
-  public:
-    virtual bool alt_block_added(const block &block, const std::vector<transaction>& txs, struct checkpoint_t const *checkpoint) = 0;
   };
 
 #pragma pack(push, 1)

--- a/src/cryptonote_basic/cryptonote_basic_impl.h
+++ b/src/cryptonote_basic/cryptonote_basic_impl.h
@@ -42,7 +42,7 @@ namespace cryptonote {
     const std::vector<transaction>& txs;
     const checkpoint_t* const checkpoint;
   };
-  using BlockAddedHook = std::function<bool(const block_added_info& info)>;
+  using BlockAddedHook = std::function<void(const block_added_info& info)>;
   struct detached_info {
     uint64_t height;
     bool by_pop_blocks;
@@ -56,7 +56,7 @@ namespace cryptonote {
     const block_reward_parts& reward_parts;
     const std::vector<cryptonote::batch_sn_payment>& batched_sn_payments;
   };
-  using ValidateMinerTxHook = std::function<bool(const miner_tx_info& info)>;
+  using ValidateMinerTxHook = std::function<void(const miner_tx_info& info)>;
 
   struct address_parse_info
   {

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -401,9 +401,10 @@ bool Blockchain::load_missing_blocks_into_oxen_subsystems()
         if (blk.major_version >= hf::hf13_enforce_checkpoints && get_checkpoint(block_height, checkpoint))
             checkpoint_ptr = &checkpoint;
 
-        if (!m_service_node_list.block_added(blk, txs, checkpoint_ptr))
-        {
-          MFATAL("Unable to process block for updating service node list: " << cryptonote::get_block_hash(blk));
+        try {
+          m_service_node_list.block_added(blk, txs, checkpoint_ptr);
+        } catch (const std::exception& e) {
+          MFATAL("Unable to process block {} for updating service node list: " << e.what());
           return false;
         }
         snl_iteration_duration += clock::now() - snl_start;
@@ -604,7 +605,7 @@ bool Blockchain::init(BlockchainDB* db, sqlite3 *ons_db, std::shared_ptr<crypton
   }
 
 
-  hook_block_added([this] (const auto& info) { return m_checkpoints.block_added(info); });
+  hook_block_added([this] (const auto& info) { m_checkpoints.block_added(info); });
   hook_blockchain_detached([this] (const auto& info) { m_checkpoints.blockchain_detached(info.height); });
   for (const auto& hook : m_init_hooks)
     hook();
@@ -1384,8 +1385,12 @@ bool Blockchain::validate_miner_transaction(const block& b, size_t cumulative_bl
   miner_tx_info hook_data{b, reward_parts, batched_sn_payments};
   for (const auto& hook : m_validate_miner_tx_hooks)
   {
-    if (!hook(hook_data))
+    try {
+      hook(hook_data);
+    } catch (const std::exception& e) {
+      MGINFO_RED("Miner tx failed validation: " << e.what());
       return false;
+    }
   }
 
   if (already_generated_coins != 0 && block_has_governance_output(nettype(), b) && version < hf::hf19_reward_batching)
@@ -2100,8 +2105,12 @@ bool Blockchain::handle_alternative_block(const block& b, const crypto::hash& id
     block_added_info hook_data{b, txs, checkpoint};
     for (const auto& hook : m_alt_block_added_hooks)
     {
-      if (!hook(hook_data))
-          return false;
+      try {
+        hook(hook_data);
+      } catch (const std::exception& e) {
+        LOG_PRINT_L1("Failed to add alt block: " << e.what());
+        return false;
+      }
     }
   }
 
@@ -4522,9 +4531,10 @@ bool Blockchain::handle_block_to_main_chain(const block& bl, const crypto::hash&
   for (std::pair<transaction, std::string> const &tx_pair : txs)
     only_txs.push_back(tx_pair.first);
 
-  if (!m_service_node_list.block_added(bl, only_txs, checkpoint))
-  {
-    MGINFO_RED("Failed to add block to Service Node List.");
+  try {
+    m_service_node_list.block_added(bl, only_txs, checkpoint);
+  } catch (const std::exception& e) {
+    MGINFO_RED("Failed to add block to Service Node List: " << e.what());
     bvc.m_verifivation_failed = true;
     return false;
   }
@@ -4551,9 +4561,10 @@ bool Blockchain::handle_block_to_main_chain(const block& bl, const crypto::hash&
   block_added_info hook_data{bl, only_txs, checkpoint};
   for (const auto& hook : m_block_added_hooks)
   {
-    if (!hook(hook_data))
-    {
-      MGINFO_RED("Block added hook signalled failure");
+    try {
+      hook(hook_data);
+    } catch (const std::exception& e) {
+      MGINFO_RED("Block added hook failed with exception: " << e.what());
       bvc.m_verifivation_failed = true;
       return false;
     }

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -59,7 +59,6 @@
 #include "cryptonote_core.h"
 #include "ringct/rctSigs.h"
 #include "common/perf_timer.h"
-#include "common/notify.h"
 #include "service_node_voting.h"
 #include "service_node_list.h"
 #include "common/varint.h"
@@ -1177,16 +1176,6 @@ bool Blockchain::switch_to_alternative_blockchain(const std::list<block_extended
   }
 
   get_block_longhash_reorg(split_height);
-
-  std::shared_ptr<tools::Notify> reorg_notify = m_reorg_notify;
-  if (reorg_notify)
-    reorg_notify->notify("%s", std::to_string(split_height).c_str(), "%h", std::to_string(m_db->height()).c_str(),
-        "%n", std::to_string(m_db->height() - split_height).c_str(), NULL);
-
-  std::shared_ptr<tools::Notify> block_notify = m_block_notify;
-  if (block_notify)
-    for (const auto &bei: alt_chain)
-      block_notify->notify("%s", tools::type_to_hex(get_block_hash(bei.bl)).c_str(), NULL);
 
   for (auto it = alt_chain.begin(); it != alt_chain.end(); ++it) {
     // Only the first hook gets `reorg=true`, the rest don't count as reorgs
@@ -4632,10 +4621,6 @@ bool Blockchain::handle_block_to_main_chain(const block& bl, const crypto::hash&
     block_post_add_info hook_data{bl, /*reorg=*/false};
     for (const auto& hook : m_block_post_add_hooks)
       hook(hook_data);
-
-    std::shared_ptr<tools::Notify> block_notify = m_block_notify;
-    if (block_notify)
-      block_notify->notify("%s", tools::type_to_hex(id).c_str(), NULL);
   }
 
   return true;

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -318,7 +318,7 @@ bool Blockchain::load_missing_blocks_into_oxen_subsystems()
   // If the batching database falls behind it NEEDS the service node list information at that point in time
   if (sqlite_height < snl_height)
   {
-    m_service_node_list.blockchain_detached(sqlite_height, true);
+    m_service_node_list.blockchain_detached(sqlite_height);
     snl_height = std::min(sqlite_height, m_service_node_list.height()) + 1;
   }
   start_height_options.push_back(snl_height);
@@ -604,10 +604,10 @@ bool Blockchain::init(BlockchainDB* db, sqlite3 *ons_db, std::shared_ptr<crypton
   }
 
 
-  hook_block_added(m_checkpoints);
-  hook_blockchain_detached(m_checkpoints);
-  for (InitHook* hook : m_init_hooks)
-    hook->init();
+  hook_block_added([this] (const auto& info) { return m_checkpoints.block_added(info); });
+  hook_blockchain_detached([this] (const auto& info) { m_checkpoints.blockchain_detached(info.height); });
+  for (const auto& hook : m_init_hooks)
+    hook();
 
   if (!m_db->is_read_only() && !load_missing_blocks_into_oxen_subsystems())
   {
@@ -723,9 +723,9 @@ void Blockchain::pop_blocks(uint64_t nblocks)
     return;
   }
 
-  auto split_height = m_db->height();
-  for (BlockchainDetachedHook* hook : m_blockchain_detached_hooks)
-    hook->blockchain_detached(split_height, true /*by_pop_blocks*/);
+  detached_info hook_data{m_db->height(), /*by_pop_blocks=*/true};
+  for (const auto& hook : m_blockchain_detached_hooks)
+    hook(hook_data);
   if (!pop_batching_rewards)
     m_service_node_list.reset_batching_to_latest_height();
   load_missing_blocks_into_oxen_subsystems();
@@ -824,8 +824,8 @@ bool Blockchain::reset_and_set_genesis_block(const block& b)
   m_db->reset();
   m_db->drop_alt_blocks();
 
-  for (InitHook* hook : m_init_hooks)
-    hook->init();
+  for (const auto& hook : m_init_hooks)
+    hook();
 
   db_wtxn_guard wtxn_guard(m_db);
   block_verification_context bvc{};
@@ -1051,8 +1051,9 @@ bool Blockchain::rollback_blockchain_switching(const std::list<block_and_checkpo
   }
 
   // Revert all changes from switching to the alt chain before adding the original chain back in
-  for (BlockchainDetachedHook* hook : m_blockchain_detached_hooks)
-    hook->blockchain_detached(rollback_height, false /*by_pop_blocks*/);
+  detached_info rollback_hook_data{rollback_height, /*by_pop_blocks=*/false};
+  for (const auto& hook : m_blockchain_detached_hooks)
+    hook(rollback_hook_data);
   load_missing_blocks_into_oxen_subsystems();
 
   //return back original chain
@@ -1113,8 +1114,9 @@ bool Blockchain::switch_to_alternative_blockchain(const std::list<block_extended
   }
 
   auto split_height = m_db->height();
-  for (BlockchainDetachedHook* hook : m_blockchain_detached_hooks)
-    hook->blockchain_detached(split_height, false /*by_pop_blocks*/);
+  detached_info split_hook_data{split_height, /*by_pop_blocks=*/false};
+  for (const auto& hook : m_blockchain_detached_hooks)
+    hook(split_hook_data);
   load_missing_blocks_into_oxen_subsystems();
 
   //connecting new alternative chain
@@ -1379,10 +1381,10 @@ bool Blockchain::validate_miner_transaction(const block& b, size_t cumulative_bl
     if (m_nettype != network_type::FAKECHAIN)
       throw std::logic_error("Blockchain missing SQLite Database");
   }
-  cryptonote::block bl = b;
-  for (ValidateMinerTxHook* hook : m_validate_miner_tx_hooks)
+  miner_tx_info hook_data{b, reward_parts, batched_sn_payments};
+  for (const auto& hook : m_validate_miner_tx_hooks)
   {
-    if (!hook->validate_miner_tx(b, reward_parts, batched_sn_payments))
+    if (!hook(hook_data))
       return false;
   }
 
@@ -2095,9 +2097,10 @@ bool Blockchain::handle_alternative_block(const block& b, const crypto::hash& id
       txs.push_back(tx);
     }
 
-    for (AltBlockAddedHook *hook : m_alt_block_added_hooks)
+    block_added_info hook_data{b, txs, checkpoint};
+    for (const auto& hook : m_alt_block_added_hooks)
     {
-      if (!hook->alt_block_added(b, txs, checkpoint))
+      if (!hook(hook_data))
           return false;
     }
   }
@@ -4502,9 +4505,9 @@ bool Blockchain::handle_block_to_main_chain(const block& bl, const crypto::hash&
 
   auto abort_block = oxen::defer([&]() {
       pop_block_from_blockchain();
-      auto old_height = m_db->height();
-      for (BlockchainDetachedHook* hook : m_blockchain_detached_hooks)
-        hook->blockchain_detached(old_height, false /*by_pop_blocks*/);
+      detached_info hook_data{m_db->height(), false /*by_pop_blocks*/};
+      for (const auto& hook : m_blockchain_detached_hooks)
+        hook(hook_data);
   });
 
   // TODO(oxen): Not nice, making the hook take in a vector of pair<transaction,
@@ -4545,9 +4548,10 @@ bool Blockchain::handle_block_to_main_chain(const block& bl, const crypto::hash&
       throw std::logic_error("Blockchain missing SQLite Database");
   }
 
-  for (BlockAddedHook* hook : m_block_added_hooks)
+  block_added_info hook_data{bl, only_txs, checkpoint};
+  for (const auto& hook : m_block_added_hooks)
   {
-    if (!hook->block_added(bl, only_txs, checkpoint))
+    if (!hook(hook_data))
     {
       MGINFO_RED("Block added hook signalled failure");
       bvc.m_verifivation_failed = true;

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -979,14 +979,22 @@ namespace cryptonote
 
     /**
      * @brief add a hook for processing new blocks and rollbacks for reorgs
-     *
-     * TODO: replace these with more versatile std::functions
      */
-    void hook_block_added        (BlockAddedHook& hook)         { m_block_added_hooks.push_back(&hook); }
-    void hook_blockchain_detached(BlockchainDetachedHook& hook) { m_blockchain_detached_hooks.push_back(&hook); }
-    void hook_init               (InitHook& hook)               { m_init_hooks.push_back(&hook); }
-    void hook_validate_miner_tx  (ValidateMinerTxHook& hook)    { m_validate_miner_tx_hooks.push_back(&hook); }
-    void hook_alt_block_added    (AltBlockAddedHook& hook)      { m_alt_block_added_hooks.push_back(&hook); }
+    void hook_block_added(BlockAddedHook hook) {
+      m_block_added_hooks.push_back(std::move(hook));
+    }
+    void hook_blockchain_detached(BlockchainDetachedHook hook) {
+      m_blockchain_detached_hooks.push_back(std::move(hook));
+    }
+    void hook_init(InitHook hook) {
+      m_init_hooks.push_back(std::move(hook));
+    }
+    void hook_validate_miner_tx(ValidateMinerTxHook hook) {
+      m_validate_miner_tx_hooks.push_back(std::move(hook));
+    }
+    void hook_alt_block_added(BlockAddedHook hook) {
+      m_alt_block_added_hooks.push_back(std::move(hook));
+    }
 
     /**
      * @brief returns the timestamps of the last N blocks
@@ -1119,11 +1127,11 @@ namespace cryptonote
     // some invalid blocks
     std::set<crypto::hash> m_invalid_blocks;
 
-    std::vector<BlockAddedHook*> m_block_added_hooks;
-    std::vector<BlockchainDetachedHook*> m_blockchain_detached_hooks;
-    std::vector<InitHook*> m_init_hooks;
-    std::vector<ValidateMinerTxHook*> m_validate_miner_tx_hooks;
-    std::vector<AltBlockAddedHook*> m_alt_block_added_hooks;
+    std::vector<BlockAddedHook> m_block_added_hooks;
+    std::vector<BlockAddedHook> m_alt_block_added_hooks;
+    std::vector<BlockchainDetachedHook> m_blockchain_detached_hooks;
+    std::vector<InitHook> m_init_hooks;
+    std::vector<ValidateMinerTxHook> m_validate_miner_tx_hooks;
 
     checkpoints m_checkpoints;
 

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -978,23 +978,26 @@ namespace cryptonote
     void on_new_tx_from_block(const cryptonote::transaction &tx);
 
     /**
-     * @brief add a hook for processing new blocks and rollbacks for reorgs
+     * @brief add a hook called during new block handling; should throw to abort adding the block.
      */
-    void hook_block_added(BlockAddedHook hook) {
-      m_block_added_hooks.push_back(std::move(hook));
-    }
-    void hook_blockchain_detached(BlockchainDetachedHook hook) {
-      m_blockchain_detached_hooks.push_back(std::move(hook));
-    }
-    void hook_init(InitHook hook) {
-      m_init_hooks.push_back(std::move(hook));
-    }
-    void hook_validate_miner_tx(ValidateMinerTxHook hook) {
-      m_validate_miner_tx_hooks.push_back(std::move(hook));
-    }
-    void hook_alt_block_added(BlockAddedHook hook) {
-      m_alt_block_added_hooks.push_back(std::move(hook));
-    }
+    void hook_block_added(BlockAddedHook hook) { m_block_added_hooks.push_back(std::move(hook)); }
+    /**
+     * @brief add a hook called when blocks are removed from the chain.
+     */
+    void hook_blockchain_detached(BlockchainDetachedHook hook) { m_blockchain_detached_hooks.push_back(std::move(hook)); }
+    /**
+     * @brief add a hook called during startup and re-initialization
+     */
+    void hook_init(InitHook hook) { m_init_hooks.push_back(std::move(hook)); }
+    /**
+     * @brief add a hook to be called to validate miner txes; should throw if the miner tx is
+     * invalid.
+     */
+    void hook_validate_miner_tx(ValidateMinerTxHook hook) { m_validate_miner_tx_hooks.push_back(std::move(hook)); }
+    /**
+     * @brief add a hook to be called when adding an alt-chain block; should throw to abort adding.
+     */
+    void hook_alt_block_added(BlockAddedHook hook) { m_alt_block_added_hooks.push_back(std::move(hook)); }
 
     /**
      * @brief returns the timestamps of the last N blocks

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -779,20 +779,6 @@ namespace cryptonote
         blockchain_db_sync_mode sync_mode, bool fast_sync);
 
     /**
-     * @brief sets a block notify object to call for every new block
-     *
-     * @param notify the notify object to call at every new block
-     */
-    void set_block_notify(const std::shared_ptr<tools::Notify> &notify) { m_block_notify = notify; }
-
-    /**
-     * @brief sets a reorg notify object to call for every reorg
-     *
-     * @param notify the notify object to call at every reorg
-     */
-    void set_reorg_notify(const std::shared_ptr<tools::Notify> &notify) { m_reorg_notify = notify; }
-
-    /**
      * @brief Put DB in safe sync mode
      */
     void safesyncmode(const bool onoff);
@@ -1163,9 +1149,6 @@ namespace cryptonote
 
     bool m_batch_success;
 
-    std::shared_ptr<tools::Notify> m_block_notify;
-    std::shared_ptr<tools::Notify> m_reorg_notify;
-
     // for prepare_handle_incoming_blocks
     uint64_t m_prepare_height;
     uint64_t m_prepare_nblocks;
@@ -1272,7 +1255,7 @@ namespace cryptonote
      * @param bl the block to be added
      * @param id the hash of the block
      * @param bvc metadata concerning the block's validity
-     * @param notify if set to true, sends new block notification on success
+     * @param notify if set to true, fires post-add hooks on success
      *
      * @return true if the block was added successfully, otherwise false
      */

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -982,6 +982,12 @@ namespace cryptonote
      */
     void hook_block_add(BlockAddHook hook) { m_block_add_hooks.push_back(std::move(hook)); }
     /**
+     * @brief add a hook to be called after a new block has been added to the (main) chain.  Unlike
+     * the above, this only fires after addition is complete and successful, while the above hook is
+     * part of the addition process.
+     */
+    void hook_block_post_add(BlockPostAddHook hook) { m_block_post_add_hooks.push_back(std::move(hook)); }
+    /**
      * @brief add a hook called when blocks are removed from the chain.
      */
     void hook_blockchain_detached(BlockchainDetachedHook hook) { m_blockchain_detached_hooks.push_back(std::move(hook)); }
@@ -1132,6 +1138,7 @@ namespace cryptonote
 
     std::vector<BlockAddHook> m_block_add_hooks;
     std::vector<BlockAddHook> m_alt_block_add_hooks;
+    std::vector<BlockPostAddHook> m_block_post_add_hooks;
     std::vector<BlockchainDetachedHook> m_blockchain_detached_hooks;
     std::vector<InitHook> m_init_hooks;
     std::vector<ValidateMinerTxHook> m_validate_miner_tx_hooks;

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -980,7 +980,7 @@ namespace cryptonote
     /**
      * @brief add a hook called during new block handling; should throw to abort adding the block.
      */
-    void hook_block_added(BlockAddedHook hook) { m_block_added_hooks.push_back(std::move(hook)); }
+    void hook_block_add(BlockAddHook hook) { m_block_add_hooks.push_back(std::move(hook)); }
     /**
      * @brief add a hook called when blocks are removed from the chain.
      */
@@ -997,7 +997,7 @@ namespace cryptonote
     /**
      * @brief add a hook to be called when adding an alt-chain block; should throw to abort adding.
      */
-    void hook_alt_block_added(BlockAddedHook hook) { m_alt_block_added_hooks.push_back(std::move(hook)); }
+    void hook_alt_block_add(BlockAddHook hook) { m_alt_block_add_hooks.push_back(std::move(hook)); }
 
     /**
      * @brief returns the timestamps of the last N blocks
@@ -1130,8 +1130,8 @@ namespace cryptonote
     // some invalid blocks
     std::set<crypto::hash> m_invalid_blocks;
 
-    std::vector<BlockAddedHook> m_block_added_hooks;
-    std::vector<BlockAddedHook> m_alt_block_added_hooks;
+    std::vector<BlockAddHook> m_block_add_hooks;
+    std::vector<BlockAddHook> m_alt_block_add_hooks;
     std::vector<BlockchainDetachedHook> m_blockchain_detached_hooks;
     std::vector<InitHook> m_init_hooks;
     std::vector<ValidateMinerTxHook> m_validate_miner_tx_hooks;

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -771,11 +771,11 @@ namespace cryptonote
       m_blockchain_storage.hook_blockchain_detached([this] (const auto& info) { m_service_node_list.blockchain_detached(info.height); });
       m_blockchain_storage.hook_init([this] { m_service_node_list.init(); });
       m_blockchain_storage.hook_validate_miner_tx([this] (const auto& info) { m_service_node_list.validate_miner_tx(info); });
-      m_blockchain_storage.hook_alt_block_added([this] (const auto& info) { m_service_node_list.alt_block_added(info); });
+      m_blockchain_storage.hook_alt_block_add([this] (const auto& info) { m_service_node_list.alt_block_add(info); });
 
       // NOTE: There is an implicit dependency on service node lists being hooked first!
       m_blockchain_storage.hook_init([this] { m_quorum_cop.init(); });
-      m_blockchain_storage.hook_block_added([this] (const auto& info) { m_quorum_cop.block_added(info.block, info.txs); });
+      m_blockchain_storage.hook_block_add([this] (const auto& info) { m_quorum_cop.block_add(info.block, info.txs); });
       m_blockchain_storage.hook_blockchain_detached([this] (const auto& info) { m_quorum_cop.blockchain_detached(info.height, info.by_pop_blocks); });
     }
 

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -768,14 +768,14 @@ namespace cryptonote
       m_service_node_list.set_quorum_history_storage(command_line::get_arg(vm, arg_store_quorum_history));
 
       // NOTE: Implicit dependency. Service node list needs to be hooked before checkpoints.
-      m_blockchain_storage.hook_blockchain_detached([this] (const auto& info) { return m_service_node_list.blockchain_detached(info.height); });
+      m_blockchain_storage.hook_blockchain_detached([this] (const auto& info) { m_service_node_list.blockchain_detached(info.height); });
       m_blockchain_storage.hook_init([this] { m_service_node_list.init(); });
-      m_blockchain_storage.hook_validate_miner_tx([this] (const auto& info) { return m_service_node_list.validate_miner_tx(info); });
-      m_blockchain_storage.hook_alt_block_added([this] (const auto& info) { return m_service_node_list.alt_block_added(info); });
+      m_blockchain_storage.hook_validate_miner_tx([this] (const auto& info) { m_service_node_list.validate_miner_tx(info); });
+      m_blockchain_storage.hook_alt_block_added([this] (const auto& info) { m_service_node_list.alt_block_added(info); });
 
       // NOTE: There is an implicit dependency on service node lists being hooked first!
       m_blockchain_storage.hook_init([this] { m_quorum_cop.init(); });
-      m_blockchain_storage.hook_block_added([this] (const auto& info) { return m_quorum_cop.block_added(info.block, info.txs); });
+      m_blockchain_storage.hook_block_added([this] (const auto& info) { m_quorum_cop.block_added(info.block, info.txs); });
       m_blockchain_storage.hook_blockchain_detached([this] (const auto& info) { m_quorum_cop.blockchain_detached(info.height, info.by_pop_blocks); });
     }
 

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -768,15 +768,15 @@ namespace cryptonote
       m_service_node_list.set_quorum_history_storage(command_line::get_arg(vm, arg_store_quorum_history));
 
       // NOTE: Implicit dependency. Service node list needs to be hooked before checkpoints.
-      m_blockchain_storage.hook_blockchain_detached(m_service_node_list);
-      m_blockchain_storage.hook_init(m_service_node_list);
-      m_blockchain_storage.hook_validate_miner_tx(m_service_node_list);
-      m_blockchain_storage.hook_alt_block_added(m_service_node_list);
+      m_blockchain_storage.hook_blockchain_detached([this] (const auto& info) { return m_service_node_list.blockchain_detached(info.height); });
+      m_blockchain_storage.hook_init([this] { m_service_node_list.init(); });
+      m_blockchain_storage.hook_validate_miner_tx([this] (const auto& info) { return m_service_node_list.validate_miner_tx(info); });
+      m_blockchain_storage.hook_alt_block_added([this] (const auto& info) { return m_service_node_list.alt_block_added(info); });
 
       // NOTE: There is an implicit dependency on service node lists being hooked first!
-      m_blockchain_storage.hook_init(m_quorum_cop);
-      m_blockchain_storage.hook_block_added(m_quorum_cop);
-      m_blockchain_storage.hook_blockchain_detached(m_quorum_cop);
+      m_blockchain_storage.hook_init([this] { m_quorum_cop.init(); });
+      m_blockchain_storage.hook_block_added([this] (const auto& info) { return m_quorum_cop.block_added(info.block, info.txs); });
+      m_blockchain_storage.hook_blockchain_detached([this] (const auto& info) { m_quorum_cop.blockchain_detached(info.height, info.by_pop_blocks); });
     }
 
     // Checkpoints

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -764,20 +764,20 @@ namespace cryptonote
     }
 
     // Service Nodes
-    {
-      m_service_node_list.set_quorum_history_storage(command_line::get_arg(vm, arg_store_quorum_history));
+    m_service_node_list.set_quorum_history_storage(command_line::get_arg(vm, arg_store_quorum_history));
 
-      // NOTE: Implicit dependency. Service node list needs to be hooked before checkpoints.
-      m_blockchain_storage.hook_blockchain_detached([this] (const auto& info) { m_service_node_list.blockchain_detached(info.height); });
-      m_blockchain_storage.hook_init([this] { m_service_node_list.init(); });
-      m_blockchain_storage.hook_validate_miner_tx([this] (const auto& info) { m_service_node_list.validate_miner_tx(info); });
-      m_blockchain_storage.hook_alt_block_add([this] (const auto& info) { m_service_node_list.alt_block_add(info); });
+    // NOTE: Implicit dependency. Service node list needs to be hooked before checkpoints.
+    m_blockchain_storage.hook_blockchain_detached([this] (const auto& info) { m_service_node_list.blockchain_detached(info.height); });
+    m_blockchain_storage.hook_init([this] { m_service_node_list.init(); });
+    m_blockchain_storage.hook_validate_miner_tx([this] (const auto& info) { m_service_node_list.validate_miner_tx(info); });
+    m_blockchain_storage.hook_alt_block_add([this] (const auto& info) { m_service_node_list.alt_block_add(info); });
 
-      // NOTE: There is an implicit dependency on service node lists being hooked first!
-      m_blockchain_storage.hook_init([this] { m_quorum_cop.init(); });
-      m_blockchain_storage.hook_block_add([this] (const auto& info) { m_quorum_cop.block_add(info.block, info.txs); });
-      m_blockchain_storage.hook_blockchain_detached([this] (const auto& info) { m_quorum_cop.blockchain_detached(info.height, info.by_pop_blocks); });
-    }
+    // NOTE: There is an implicit dependency on service node lists being hooked first!
+    m_blockchain_storage.hook_init([this] { m_quorum_cop.init(); });
+    m_blockchain_storage.hook_block_add([this] (const auto& info) { m_quorum_cop.block_add(info.block, info.txs); });
+    m_blockchain_storage.hook_blockchain_detached([this] (const auto& info) { m_quorum_cop.blockchain_detached(info.height, info.by_pop_blocks); });
+
+    m_blockchain_storage.hook_block_post_add([this] (const auto&) { update_omq_sns(); });
 
     // Checkpoints
     m_checkpoints_path = m_config_folder / fs::u8path(JSON_HASH_FILE_NAME);

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -226,16 +226,6 @@ namespace cryptonote
     "replaced by the number of new blocks in the new chain"
   , ""
   };
-  static const command_line::arg_descriptor<std::string> arg_block_rate_notify = {
-    "block-rate-notify"
-  , "Run a program when the block rate undergoes large fluctuations. This might "
-    "be a sign of large amounts of hash rate going on and off the Loki network, "
-    "or could be a sign that oxend is not properly synchronizing with the network. %t will be replaced "
-    "by the number of minutes for the observation window, %b by the number of "
-    "blocks observed within that window, and %e by the number of blocks that was "
-    "expected in that window."
-  , ""
-  };
   static const command_line::arg_descriptor<bool> arg_keep_alt_blocks  = {
     "keep-alt-blocks"
   , "Keep alternative blocks on restart"
@@ -351,7 +341,6 @@ namespace cryptonote
     command_line::add_arg(desc, arg_prune_blockchain);
 #endif
     command_line::add_arg(desc, arg_reorg_notify);
-    command_line::add_arg(desc, arg_block_rate_notify);
     command_line::add_arg(desc, arg_keep_alt_blocks);
 
     command_line::add_arg(desc, arg_store_quorum_history);
@@ -724,20 +713,22 @@ namespace cryptonote
     m_blockchain_storage.set_user_options(blocks_threads,
         sync_on_blocks, sync_threshold, sync_mode, fast_sync);
 
-    try
-    {
-      if (!command_line::is_arg_defaulted(vm, arg_block_notify))
-        m_blockchain_storage.set_block_notify(std::shared_ptr<tools::Notify>(new tools::Notify(command_line::get_arg(vm, arg_block_notify).c_str())));
-    }
-    catch (const std::exception &e)
-    {
-      MERROR("Failed to parse block notify spec");
-    }
-
+    // We need this hook to get added before the block hook below, so that it fires first and
+    // catches the start of a reorg before the block hook fires for the block in the reorg.
     try
     {
       if (!command_line::is_arg_defaulted(vm, arg_reorg_notify))
-        m_blockchain_storage.set_reorg_notify(std::shared_ptr<tools::Notify>(new tools::Notify(command_line::get_arg(vm, arg_reorg_notify).c_str())));
+        m_blockchain_storage.hook_block_post_add(
+            [this, notify=tools::Notify(command_line::get_arg(vm, arg_reorg_notify))]
+            (const auto& info) {
+              if (!info.reorg)
+                return;
+              auto h = get_current_blockchain_height();
+              notify.notify(
+                  "%s", info.split_height,
+                  "%h", h,
+                  "%n", h - info.split_height);
+            });
     }
     catch (const std::exception &e)
     {
@@ -746,14 +737,17 @@ namespace cryptonote
 
     try
     {
-      if (!command_line::is_arg_defaulted(vm, arg_block_rate_notify))
-        m_block_rate_notify.reset(new tools::Notify(command_line::get_arg(vm, arg_block_rate_notify).c_str()));
+      if (!command_line::is_arg_defaulted(vm, arg_block_notify))
+        m_blockchain_storage.hook_block_post_add(
+            [notify=tools::Notify(command_line::get_arg(vm, arg_block_notify))]
+            (const auto& info) {
+              notify.notify("%s", tools::type_to_hex(get_block_hash(info.block)));
+            });
     }
     catch (const std::exception &e)
     {
-      MERROR("Failed to parse block rate notify spec");
+      MERROR("Failed to parse block notify spec");
     }
-
     
     cryptonote::test_options regtest_test_options{};
     for (auto [it, end] = get_hard_forks(network_type::MAINNET);
@@ -2446,14 +2440,6 @@ namespace cryptonote
       if (p < threshold)
       {
         MWARNING("There were " << b << (b == max_blocks_checked ? " or more" : "") << " blocks in the last " << seconds[n] / 60 << " minutes, there might be large hash rate changes, or we might be partitioned, cut off from the Loki network or under attack, or your computer's time is off. Or it could be just sheer bad luck.");
-
-        std::shared_ptr<tools::Notify> block_rate_notify = m_block_rate_notify;
-        if (block_rate_notify)
-        {
-          auto expected = seconds[n] / tools::to_seconds(TARGET_BLOCK_TIME);
-          block_rate_notify->notify("%t", std::to_string(seconds[n] / 60).c_str(), "%b", std::to_string(b).c_str(), "%e", std::to_string(expected).c_str(), NULL);
-        }
-
         break; // no need to look further
       }
     }

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -1207,8 +1207,6 @@ namespace cryptonote
      bool m_offline;
      bool m_pad_transactions;
 
-     std::shared_ptr<tools::Notify> m_block_rate_notify;
-
      struct {
        std::shared_mutex mutex;
        bool building = false;

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1542,12 +1542,12 @@ namespace service_nodes
   }
 
 
-  bool service_node_list::verify_block(const cryptonote::block &block, bool alt_block, cryptonote::checkpoint_t const *checkpoint)
+  void service_node_list::verify_block(const cryptonote::block &block, bool alt_block, cryptonote::checkpoint_t const *checkpoint)
   {
     if (block.major_version < hf::hf9_service_nodes)
-      return true;
+      return;
 
-    std::string_view block_type = alt_block ? "alt block "sv : "block "sv;
+    std::string_view block_type = alt_block ? "alt block"sv : "block"sv;
 
     //
     // NOTE: Verify the checkpoint given on this height that locks in a block in the past.
@@ -1558,10 +1558,7 @@ namespace service_nodes
       std::shared_ptr<const quorum> quorum = get_quorum(quorum_type::checkpointing, checkpoint->height, false, alt_block ? &alt_quorums : nullptr);
 
       if (!quorum)
-      {
-        MGINFO("Failed to get testing quorum checkpoint for " << block_type << cryptonote::get_block_hash(block));
-        return false;
-      }
+        throw std::runtime_error{fmt::format("Failed to get testing quorum checkpoint for {} {}", block_type, cryptonote::get_block_hash(block))};
 
       bool failed_checkpoint_verify = !service_nodes::verify_checkpoint(block.major_version, *checkpoint, *quorum);
       if (alt_block && failed_checkpoint_verify)
@@ -1577,10 +1574,7 @@ namespace service_nodes
       }
 
       if (failed_checkpoint_verify)
-      {
-        MGINFO("Service node checkpoint failed verification for " << block_type << cryptonote::get_block_hash(block));
-        return false;
-      }
+        throw std::runtime_error{fmt::format("Service node checkpoint failed verification for {} {}", block_type, cryptonote::get_block_hash(block))};
     }
 
     //
@@ -1595,10 +1589,9 @@ namespace service_nodes
       {
         cryptonote::block prev_block;
         if (!find_block_in_db(m_blockchain.get_db(), block.prev_id, prev_block))
-        {
-          MGINFO("Alt block " << cryptonote::get_block_hash(block) << " references previous block " << block.prev_id << " not available in DB.");
-          return false;
-        }
+          throw std::runtime_error{fmt::format(
+              "Alt block {} references previous block {} not available in DB.",
+              cryptonote::get_block_hash(block), block.prev_id)};
 
         prev_timestamp = prev_block.timestamp;
       }
@@ -1609,10 +1602,9 @@ namespace service_nodes
       }
 
       if (!pulse::get_round_timings(m_blockchain, height, prev_timestamp, timings))
-      {
-        MGINFO("Failed to query the block data for Pulse timings to validate incoming " << block_type << "at height " << height);
-        return false;
-      }
+        throw std::runtime_error{fmt::format(
+            "Failed to query the block data for Pulse timings to validate incoming {} at height {}",
+            block_type, height)};
     }
 
     //
@@ -1670,18 +1662,20 @@ namespace service_nodes
                                        alt_pulse_quorums);
     }
 
-    return result;
+    if (!result)
+      throw std::runtime_error{fmt::format("Failed to verify block components for incoming {} at height {}",
+          block_type, height)};
   }
 
-  bool service_node_list::block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs, cryptonote::checkpoint_t const *checkpoint)
+  void service_node_list::block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs, cryptonote::checkpoint_t const *checkpoint)
   {
     if (block.major_version < hf::hf9_service_nodes)
-      return true;
+      return;
 
     std::lock_guard lock(m_sn_mutex);
     process_block(block, txs);
-    bool result = verify_block(block, false /*alt_block*/, checkpoint);
-    if (result && cryptonote::block_has_pulse_components(block))
+    verify_block(block, false /*alt_block*/, checkpoint);
+    if (cryptonote::block_has_pulse_components(block))
     {
       // NOTE: Only record participation if its a block we recently received.
       // Otherwise processing blocks in retrospect/re-loading on restart seeds
@@ -1697,10 +1691,8 @@ namespace service_nodes
       {
         std::shared_ptr<const quorum> quorum = get_quorum(quorum_type::pulse, block_height, false, nullptr);
         if (!quorum || quorum->validators.empty())
-        {
-          MFATAL("Unexpected Pulse error " << (quorum ? " quorum was not generated" : " quorum was empty"));
-          return false;
-        }
+          throw std::runtime_error{fmt::format(
+              "Unexpected Pulse error: {}", quorum ? " quorum was not generated" : " quorum was empty")};
 
         for (size_t validator_index = 0; validator_index < service_nodes::PULSE_QUORUM_NUM_VALIDATORS; validator_index++)
         {
@@ -1710,7 +1702,6 @@ namespace service_nodes
         }
       }
     }
-    return result;
   }
 
   void service_node_list::reset_batching_to_latest_height()
@@ -2442,17 +2433,15 @@ namespace service_nodes
   }
 
   // NOTE: Verify queued service node coinbase or pulse block producer rewards
-  static bool verify_coinbase_tx_output(cryptonote::transaction const &miner_tx,
+  static void verify_coinbase_tx_output(cryptonote::transaction const &miner_tx,
                                         uint64_t height,
                                         size_t output_index,
                                         cryptonote::account_public_address const &receiver,
                                         uint64_t reward)
   {
     if (output_index >= miner_tx.vout.size())
-    {
-      MGINFO_RED("Output Index: " << output_index << ", indexes out of bounds in vout array with size: " << miner_tx.vout.size());
-      return false;
-    }
+      throw std::out_of_range{fmt::format("Output Index: {} , indexes out of bounds in vout array with size: ",
+        output_index, miner_tx.vout.size())};
 
     cryptonote::tx_out const &output = miner_tx.vout[output_index];
 
@@ -2461,16 +2450,10 @@ namespace service_nodes
     // 1 ULP difference in the reward calculations.
     // TODO(oxen): eliminate all FP math from reward calculations
     if (!within_one(output.amount, reward))
-    {
-      MGINFO_RED("Service node reward amount incorrect. Should be " << cryptonote::print_money(reward) << ", is: " << cryptonote::print_money(output.amount));
-      return false;
-    }
+      throw std::runtime_error{fmt::format("Service node reward amount incorrect. Should be {}, is: {}", cryptonote::print_money(reward), cryptonote::print_money(output.amount))};
 
     if (!std::holds_alternative<cryptonote::txout_to_key>(output.target))
-    {
-      MGINFO_RED("Service node output target type should be txout_to_key");
-      return false;
-    }
+      throw std::runtime_error{"Service node output target type should be txout_to_key"};
 
     // NOTE: Loki uses the governance key in the one-time ephemeral key
     // derivation for both Pulse Block Producer/Queued Service Node Winner rewards
@@ -2478,28 +2461,23 @@ namespace service_nodes
     crypto::public_key out_eph_public_key{};
     cryptonote::keypair gov_key = cryptonote::get_deterministic_keypair_from_height(height);
 
-    bool r = crypto::generate_key_derivation(receiver.m_view_public_key, gov_key.sec, derivation);
-    CHECK_AND_ASSERT_MES(r, false, "while creating outs: failed to generate_key_derivation(" << receiver.m_view_public_key << ", " << gov_key.sec << ")");
-    r = crypto::derive_public_key(derivation, output_index, receiver.m_spend_public_key, out_eph_public_key);
-    CHECK_AND_ASSERT_MES(r, false, "while creating outs: failed to derive_public_key(" << derivation << ", " << output_index << ", "<< receiver.m_spend_public_key << ")");
+    if (!crypto::generate_key_derivation(receiver.m_view_public_key, gov_key.sec, derivation))
+      throw std::runtime_error{"Failed to generate key derivation"};
+    if (!crypto::derive_public_key(derivation, output_index, receiver.m_spend_public_key, out_eph_public_key))
+      throw std::runtime_error{"Failed derive public key"};
 
     if (var::get<cryptonote::txout_to_key>(output.target).key != out_eph_public_key)
-    {
-      MGINFO_RED("Invalid service node reward at output: " << output_index << ", output key, specifies wrong key");
-      return false;
-    }
-
-    return true;
+      throw std::runtime_error{fmt::format("Invalid service node reward at output: {}, output key, specifies wrong key", output_index)};
   }
 
-  bool service_node_list::validate_miner_tx(const cryptonote::miner_tx_info& info) const
+  void service_node_list::validate_miner_tx(const cryptonote::miner_tx_info& info) const
   {
     const auto& block = info.block;
     const auto& reward_parts = info.reward_parts;
     const auto& batched_sn_payments = info.batched_sn_payments;
     const auto hf_version = block.major_version;
     if (hf_version < hf::hf9_service_nodes)
-      return true;
+      return;
 
     std::lock_guard lock(m_sn_mutex);
     uint64_t const height                   = cryptonote::get_block_height(block);
@@ -2514,10 +2492,7 @@ namespace service_nodes
     {
       auto const check_block_leader_pubkey = cryptonote::get_service_node_winner_from_tx_extra(miner_tx.extra);
       if (block_leader.key != check_block_leader_pubkey)
-      {
-        MGINFO_RED("Service node reward winner is incorrect! Expected " << block_leader.key << ", block has " << check_block_leader_pubkey);
-        return false;
-      }
+        throw std::runtime_error{fmt::format("Service node reward winner is incorrect! Expected {}, block has {}", block_leader.key, check_block_leader_pubkey)};
     }
 
     enum struct verify_mode
@@ -2539,20 +2514,14 @@ namespace service_nodes
       std::vector<crypto::hash> entropy = get_pulse_entropy_for_next_block(m_blockchain.get_db(), block.prev_id, block.pulse.round);
       quorum pulse_quorum = generate_pulse_quorum(m_blockchain.nettype(), block_leader.key, hf_version, m_state.active_service_nodes_infos(), entropy, block.pulse.round);
       if (!verify_pulse_quorum_sizes(pulse_quorum))
-      {
-        MGINFO_RED("Pulse block received but Pulse has insufficient nodes for quorum, block hash " << cryptonote::get_block_hash(block) << ", height " << height);
-        return false;
-      }
+        throw std::runtime_error{fmt::format("Pulse block received but Pulse has insufficient nodes for quorum, block hash {}, height {}", cryptonote::get_block_hash(block), height)};
 
       block_producer_key = pulse_quorum.workers[0];
       mode               = (block_producer_key == block_leader.key) ? verify_mode::pulse_block_leader_is_producer
                                                                     : verify_mode::pulse_different_block_producer;
 
       if (block.pulse.round == 0 && (mode == verify_mode::pulse_different_block_producer))
-      {
-        MGINFO_RED("The block producer in pulse round 0 should be the same node as the block leader: " << block_leader.key << ", actual producer: " << block_producer_key);
-        return false;
-      }
+        throw std::runtime_error{fmt::format("The block producer in pulse round 0 should be the same node as the block leader: {}, actual producer: {}", block_leader.key, block_producer_key)};
     }
 
     // NOTE: Verify miner tx vout composition
@@ -2588,10 +2557,7 @@ namespace service_nodes
         {
           auto info_it = m_state.service_nodes_infos.find(block_producer_key);
           if (info_it == m_state.service_nodes_infos.end())
-          {
-            MGINFO_RED("The pulse block producer for round: " << +block.pulse.round << " is not currently a Service Node: " << block_producer_key);
-            return false;
-          }
+            throw std::runtime_error{fmt::format("The pulse block producer for round {:d} is not current a Service Node: {}", block.pulse.round, block_producer_key)};
 
           block_producer = info_it->second;
           expected_vouts_size = mode == verify_mode::pulse_different_block_producer && reward_parts.miner_fee > 0
@@ -2613,20 +2579,16 @@ namespace service_nodes
     }
 
     if (miner_tx.vout.size() != expected_vouts_size)
-    {
-      auto type =
-        mode == verify_mode::miner ? "miner"sv :
-        mode == verify_mode::batched_sn_rewards ? "batch reward"sv :
-        mode == verify_mode::pulse_block_leader_is_producer ? "pulse"sv : "pulse alt round"sv;
-      MGINFO_RED("Expected " << type << " block, the miner TX specifies a different amount of outputs vs the expected: " << expected_vouts_size << ", miner tx outputs: " << miner_tx.vout.size());
-      return false;
-    }
+      throw std::runtime_error{fmt::format("Expected {} block, the miner TX specifies a different amount of outputs vs the expected: {}, miner tx outputs: {}",
+          mode == verify_mode::miner ? "miner"sv :
+          mode == verify_mode::batched_sn_rewards ? "batch reward"sv :
+          mode == verify_mode::pulse_block_leader_is_producer ? "pulse"sv :
+          "pulse alt round"sv,
+          expected_vouts_size,
+          miner_tx.vout.size())};
 
     if (hf_version >= hf::hf16_pulse && reward_parts.base_miner != 0)
-    {
-      MGINFO_RED("Miner reward is incorrect expected 0 reward, block specified " << cryptonote::print_money(reward_parts.base_miner));
-      return false;
-    }
+      throw std::runtime_error{fmt::format("Miner reward is incorrect expected 0 reward, block specified {}", cryptonote::print_money(reward_parts.base_miner))};
 
     // NOTE: Verify Coinbase Amounts
     switch(mode)
@@ -2649,8 +2611,7 @@ namespace service_nodes
           const auto& payout = block_leader.payouts[i];
           if (split_rewards[i])
           {
-            if (!verify_coinbase_tx_output(miner_tx, height, vout_index, payout.address, split_rewards[i]))
-              return false;
+            verify_coinbase_tx_output(miner_tx, height, vout_index, payout.address, split_rewards[i]);
             vout_index++;
           }
         }
@@ -2669,8 +2630,7 @@ namespace service_nodes
           const auto& payout = block_leader.payouts[i];
           if (split_rewards[i])
           {
-            if (!verify_coinbase_tx_output(miner_tx, height, vout_index, payout.address, split_rewards[i]))
-              return false;
+            verify_coinbase_tx_output(miner_tx, height, vout_index, payout.address, split_rewards[i]);
             vout_index++;
           }
         }
@@ -2688,8 +2648,7 @@ namespace service_nodes
             const auto& payout = block_producer_payouts.payouts[i];
             if (split_rewards[i])
             {
-              if (!verify_coinbase_tx_output(miner_tx, height, vout_index, payout.address, split_rewards[i]))
-                return false;
+              verify_coinbase_tx_output(miner_tx, height, vout_index, payout.address, split_rewards[i]);
               vout_index++;
             }
           }
@@ -2701,8 +2660,7 @@ namespace service_nodes
           const auto& payout = block_leader.payouts[i];
           if (split_rewards[i])
           {
-            if (!verify_coinbase_tx_output(miner_tx, height, vout_index, payout.address, split_rewards[i]))
-              return false;
+            verify_coinbase_tx_output(miner_tx, height, vout_index, payout.address, split_rewards[i]);
             vout_index++;
           }
         }
@@ -2726,52 +2684,33 @@ namespace service_nodes
           const auto& batch_payment = batched_sn_payments[vout_index];
 
           if (!std::holds_alternative<cryptonote::txout_to_key>(vout.target))
-          {
-            MGINFO_RED("Service node output target type should be txout_to_key");
-            return false;
-          }
+            throw std::runtime_error{"Service node output target type should be txout_to_key"};
 
           constexpr uint64_t max_amount = std::numeric_limits<uint64_t>::max() / cryptonote::BATCH_REWARD_FACTOR;
           if (vout.amount > max_amount)
-          {
-            // We should never actually hit this limit unless someone is trying something nefarious
-            MGINFO_RED("Batched reward payout invalid: exceeds maximum possible payout size");
-            return false;
-          }
+            throw std::runtime_error{"Batched reward payout invalid: exceeds maximum possible payout size"};
 
           auto paid_amount = vout.amount * cryptonote::BATCH_REWARD_FACTOR;
           total_payout_in_vouts += paid_amount;
           if (paid_amount != batch_payment.amount)
-          {
-            MGINFO_RED(fmt::format("Batched reward payout incorrect: expected {}, not {}", batch_payment.amount, paid_amount));
-            return false;
-          }
+            throw std::runtime_error{fmt::format("Batched reward payout incorrect: expected {}, not {}", batch_payment.amount, paid_amount)};
+
           crypto::public_key out_eph_public_key{};
           if (!cryptonote::get_deterministic_output_key(batch_payment.address_info.address, deterministic_keypair, vout_index, out_eph_public_key))
-          {
-            MGINFO_RED("Failed to generate output one-time public key");
-            return false;
-          }
+            throw std::runtime_error{"Failed to generate output one-time public key"};
+
           const auto& out_to_key = var::get<cryptonote::txout_to_key>(vout.target);
           if (tools::view_guts(out_to_key) != tools::view_guts(out_eph_public_key))
-          {
-            MGINFO_RED("Output Ephermeral Public Key does not match (payment to wrong recipient)");
-            return false;
-          }
+            throw std::runtime_error{"Output Ephermeral Public Key does not match (payment to wrong recipient)"};
         }
         if (total_payout_in_vouts != total_payout_in_our_db)
-        {
-          MGINFO_RED(fmt::format("Total service node reward amount incorrect: expected {}, not {}", total_payout_in_our_db, total_payout_in_vouts));
-          return false;
-        }
+          throw std::runtime_error{fmt::format("Total service node reward amount incorrect: expected {}, not {}", total_payout_in_our_db, total_payout_in_vouts)};
       }
       break;
     }
-
-    return true;
   }
 
-  bool service_node_list::alt_block_added(const cryptonote::block_added_info& info)
+  void service_node_list::alt_block_added(const cryptonote::block_added_info& info)
   {
     // NOTE: The premise is to search the main list and the alternative list for
     // the parent of the block we just received, generate the new Service Node
@@ -2784,14 +2723,14 @@ namespace service_nodes
 
     auto& block = info.block;
     if (block.major_version < hf::hf9_service_nodes)
-      return true;
+      return;
 
     uint64_t block_height         = cryptonote::get_block_height(block);
     state_t const *starting_state = nullptr;
     crypto::hash const block_hash = get_block_hash(block);
 
     auto it = m_transient.alt_state.find(block_hash);
-    if (it != m_transient.alt_state.end()) return true; // NOTE: Already processed alt-state for this block
+    if (it != m_transient.alt_state.end()) return; // NOTE: Already processed alt-state for this block
 
     // NOTE: Check if alt block forks off some historical state on the canonical chain
     if (!starting_state)
@@ -2809,17 +2748,11 @@ namespace service_nodes
     }
 
     if (!starting_state)
-    {
-      LOG_PRINT_L1("Received alt block but couldn't find parent state in historical state");
-      return false;
-    }
+      throw std::runtime_error{"Received alt block but couldn't find parent state in historical state"};
 
     if (starting_state->block_hash != block.prev_id)
-    {
-      LOG_PRINT_L1("Unexpected state_t's hash: " << starting_state->block_hash
-                                                 << ", does not match the block prev hash: " << block.prev_id);
-      return false;
-    }
+      throw std::runtime_error{fmt::format("Unexpected state_t's hash: {}, does not match the block prev hash: {}",
+         starting_state->block_hash, block.prev_id)};
 
     // NOTE: Generate the next Service Node list state from this Alt block.
     state_t alt_state = *starting_state;
@@ -2830,7 +2763,7 @@ namespace service_nodes
     else
       m_transient.alt_state.emplace(block_hash, std::move(alt_state));
 
-    return verify_block(block, true /*alt_block*/, info.checkpoint);
+    verify_block(block, true /*alt_block*/, info.checkpoint);
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1667,7 +1667,7 @@ namespace service_nodes
           block_type, height)};
   }
 
-  void service_node_list::block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs, cryptonote::checkpoint_t const *checkpoint)
+  void service_node_list::block_add(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs, cryptonote::checkpoint_t const *checkpoint)
   {
     if (block.major_version < hf::hf9_service_nodes)
       return;
@@ -2710,7 +2710,7 @@ namespace service_nodes
     }
   }
 
-  void service_node_list::alt_block_added(const cryptonote::block_added_info& info)
+  void service_node_list::alt_block_add(const cryptonote::block_add_info& info)
   {
     // NOTE: The premise is to search the main list and the alternative list for
     // the parent of the block we just received, generate the new Service Node

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -455,7 +455,7 @@ namespace service_nodes
     service_node_list(const service_node_list &) = delete;
     service_node_list &operator=(const service_node_list &) = delete;
 
-    void block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs, const cryptonote::checkpoint_t* checkpoint);
+    void block_add(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs, const cryptonote::checkpoint_t* checkpoint);
     void reset_batching_to_latest_height();
     bool state_history_exists(uint64_t height);
     bool process_batching_rewards(const cryptonote::block& block);
@@ -463,7 +463,7 @@ namespace service_nodes
     void blockchain_detached(uint64_t height);
     void init();
     void validate_miner_tx(const cryptonote::miner_tx_info& info) const;
-    void alt_block_added(const cryptonote::block_added_info& info);
+    void alt_block_add(const cryptonote::block_add_info& info);
     payout get_block_leader() const { std::lock_guard lock{m_sn_mutex}; return m_state.get_block_leader(); }
     bool is_service_node(const crypto::public_key& pubkey, bool require_active = true) const;
     bool is_key_image_locked(crypto::key_image const &check_image, uint64_t *unlock_height = nullptr, service_node_info::contribution_t *the_locked_contribution = nullptr) const;

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -455,15 +455,15 @@ namespace service_nodes
     service_node_list(const service_node_list &) = delete;
     service_node_list &operator=(const service_node_list &) = delete;
 
-    bool block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs, const cryptonote::checkpoint_t* checkpoint);
+    void block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs, const cryptonote::checkpoint_t* checkpoint);
     void reset_batching_to_latest_height();
     bool state_history_exists(uint64_t height);
     bool process_batching_rewards(const cryptonote::block& block);
     bool pop_batching_rewards_block(const cryptonote::block& block);
     void blockchain_detached(uint64_t height);
     void init();
-    bool validate_miner_tx(const cryptonote::miner_tx_info& info) const;
-    bool alt_block_added(const cryptonote::block_added_info& info);
+    void validate_miner_tx(const cryptonote::miner_tx_info& info) const;
+    void alt_block_added(const cryptonote::block_added_info& info);
     payout get_block_leader() const { std::lock_guard lock{m_sn_mutex}; return m_state.get_block_leader(); }
     bool is_service_node(const crypto::public_key& pubkey, bool require_active = true) const;
     bool is_key_image_locked(crypto::key_image const &check_image, uint64_t *unlock_height = nullptr, service_node_info::contribution_t *the_locked_contribution = nullptr) const;
@@ -739,7 +739,7 @@ namespace service_nodes
     void record_pulse_participation(crypto::public_key const &pubkey, uint64_t height, uint8_t round, bool participated);
 
     // Verify block against Service Node state that has just been called with 'state.update_from_block(block)'.
-    bool verify_block(const cryptonote::block& block, bool alt_block, cryptonote::checkpoint_t const *checkpoint);
+    void verify_block(const cryptonote::block& block, bool alt_block, cryptonote::checkpoint_t const *checkpoint);
 
     void reset(bool delete_db_entry = false);
     bool load(uint64_t current_height);

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -448,11 +448,6 @@ namespace service_nodes
   };
 
   class service_node_list
-    : public cryptonote::BlockAddedHook,
-      public cryptonote::BlockchainDetachedHook,
-      public cryptonote::InitHook,
-      public cryptonote::ValidateMinerTxHook,
-      public cryptonote::AltBlockAddedHook
   {
   public:
     explicit service_node_list(cryptonote::Blockchain& blockchain);
@@ -460,15 +455,15 @@ namespace service_nodes
     service_node_list(const service_node_list &) = delete;
     service_node_list &operator=(const service_node_list &) = delete;
 
-    bool block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs, cryptonote::checkpoint_t const *checkpoint) override;
+    bool block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs, const cryptonote::checkpoint_t* checkpoint);
     void reset_batching_to_latest_height();
     bool state_history_exists(uint64_t height);
     bool process_batching_rewards(const cryptonote::block& block);
     bool pop_batching_rewards_block(const cryptonote::block& block);
-    void blockchain_detached(uint64_t height, bool by_pop_blocks) override;
-    void init() override;
-    bool validate_miner_tx(const cryptonote::block& block, const cryptonote::block_reward_parts& base_reward, const std::optional<std::vector<cryptonote::batch_sn_payment>>& batched_sn_payments) const override;
-    bool alt_block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs, cryptonote::checkpoint_t const *checkpoint) override;
+    void blockchain_detached(uint64_t height);
+    void init();
+    bool validate_miner_tx(const cryptonote::miner_tx_info& info) const;
+    bool alt_block_added(const cryptonote::block_added_info& info);
     payout get_block_leader() const { std::lock_guard lock{m_sn_mutex}; return m_state.get_block_leader(); }
     bool is_service_node(const crypto::public_key& pubkey, bool require_active = true) const;
     bool is_key_image_locked(crypto::key_image const &check_image, uint64_t *unlock_height = nullptr, service_node_info::contribution_t *the_locked_contribution = nullptr) const;

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -510,7 +510,7 @@ namespace service_nodes
     }
   }
 
-  bool quorum_cop::block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs)
+  void quorum_cop::block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs)
   {
     process_quorums(block);
     uint64_t const height = cryptonote::get_block_height(block) + 1; // chain height = new top block height + 1
@@ -520,8 +520,6 @@ namespace service_nodes
     // These feels out of place here because the hook system sucks: TODO replace it with
     // std::function hooks instead.
     m_core.update_omq_sns();
-
-    return true;
   }
 
   static bool handle_obligations_vote(cryptonote::core &core, const quorum_vote_t& vote, const std::vector<pool_vote_entry>& votes, const quorum& quorum)

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -510,7 +510,7 @@ namespace service_nodes
     }
   }
 
-  void quorum_cop::block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs)
+  void quorum_cop::block_add(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs)
   {
     process_quorums(block);
     uint64_t const height = cryptonote::get_block_height(block) + 1; // chain height = new top block height + 1

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -516,10 +516,6 @@ namespace service_nodes
     uint64_t const height = cryptonote::get_block_height(block) + 1; // chain height = new top block height + 1
     m_vote_pool.remove_expired_votes(height);
     m_vote_pool.remove_used_votes(txs, block.major_version);
-
-    // These feels out of place here because the hook system sucks: TODO replace it with
-    // std::function hooks instead.
-    m_core.update_omq_sns();
   }
 
   static bool handle_obligations_vote(cryptonote::core &core, const quorum_vote_t& vote, const std::vector<pool_vote_entry>& votes, const quorum& quorum)

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -510,7 +510,7 @@ namespace service_nodes
     }
   }
 
-  bool quorum_cop::block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs, cryptonote::checkpoint_t const * /*checkpoint*/)
+  bool quorum_cop::block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs)
   {
     process_quorums(block);
     uint64_t const height = cryptonote::get_block_height(block) + 1; // chain height = new top block height + 1

--- a/src/cryptonote_core/service_node_quorum_cop.h
+++ b/src/cryptonote_core/service_node_quorum_cop.h
@@ -110,16 +110,13 @@ namespace service_nodes
   };
 
   class quorum_cop
-    : public cryptonote::BlockAddedHook,
-      public cryptonote::BlockchainDetachedHook,
-      public cryptonote::InitHook
   {
   public:
     explicit quorum_cop(cryptonote::core& core);
 
-    void init() override;
-    bool block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs, cryptonote::checkpoint_t const * /*checkpoint*/) override;
-    void blockchain_detached(uint64_t height, bool by_pop_blocks) override;
+    void init();
+    bool block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs);
+    void blockchain_detached(uint64_t height, bool by_pop_blocks);
 
     void                       set_votes_relayed  (std::vector<quorum_vote_t> const &relayed_votes);
     std::vector<quorum_vote_t> get_relayable_votes(uint64_t current_height, cryptonote::hf hf_version, bool quorum_relay);

--- a/src/cryptonote_core/service_node_quorum_cop.h
+++ b/src/cryptonote_core/service_node_quorum_cop.h
@@ -115,7 +115,7 @@ namespace service_nodes
     explicit quorum_cop(cryptonote::core& core);
 
     void init();
-    bool block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs);
+    void block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs);
     void blockchain_detached(uint64_t height, bool by_pop_blocks);
 
     void                       set_votes_relayed  (std::vector<quorum_vote_t> const &relayed_votes);

--- a/src/cryptonote_core/service_node_quorum_cop.h
+++ b/src/cryptonote_core/service_node_quorum_cop.h
@@ -115,7 +115,7 @@ namespace service_nodes
     explicit quorum_cop(cryptonote::core& core);
 
     void init();
-    void block_added(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs);
+    void block_add(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs);
     void blockchain_detached(uint64_t height, bool by_pop_blocks);
 
     void                       set_votes_relayed  (std::vector<quorum_vote_t> const &relayed_votes);

--- a/src/rpc/lmq_server.cpp
+++ b/src/rpc/lmq_server.cpp
@@ -315,7 +315,7 @@ omq_rpc::omq_rpc(cryptonote::core& core, core_rpc_server& rpc, const boost::prog
     }
   });
 
-  core_.get_blockchain_storage().hook_block_added([this] (const auto& info) { send_block_notifications(info.block); return true; });
+  core_.get_blockchain_storage().hook_block_add([this] (const auto& info) { send_block_notifications(info.block); return true; });
   core_.get_pool().add_notify([this](const crypto::hash& id, const transaction& tx, const std::string& blob, const tx_pool_options& opts) {
       send_mempool_notifications(id, tx, blob, opts);
   });

--- a/src/rpc/lmq_server.cpp
+++ b/src/rpc/lmq_server.cpp
@@ -315,7 +315,7 @@ omq_rpc::omq_rpc(cryptonote::core& core, core_rpc_server& rpc, const boost::prog
     }
   });
 
-  core_.get_blockchain_storage().hook_block_add([this] (const auto& info) { send_block_notifications(info.block); return true; });
+  core_.get_blockchain_storage().hook_block_post_add([this] (const auto& info) { send_block_notifications(info.block); return true; });
   core_.get_pool().add_notify([this](const crypto::hash& id, const transaction& tx, const std::string& blob, const tx_pool_options& opts) {
       send_mempool_notifications(id, tx, blob, opts);
   });

--- a/src/rpc/lmq_server.h
+++ b/src/rpc/lmq_server.h
@@ -35,7 +35,7 @@
 
 namespace oxenmq { class OxenMQ; }
 
-namespace cryptonote { namespace rpc {
+namespace cryptonote::rpc {
 
 void init_omq_options(boost::program_options::options_description& desc);
 
@@ -70,4 +70,4 @@ public:
   void send_mempool_notifications(const crypto::hash& id, const transaction& tx, const std::string& blob, const tx_pool_options& opts);
 };
 
-}} // namespace cryptonote::rpc
+} // namespace cryptonote::rpc

--- a/src/rpc/lmq_server.h
+++ b/src/rpc/lmq_server.h
@@ -44,7 +44,7 @@ void init_omq_options(boost::program_options::options_description& desc);
  * cryptonote_core--but it works with it to add RPC endpoints, make it listen on RPC ports, and
  * handles RPC requests.
  */
-class omq_rpc final : public cryptonote::BlockAddedHook {
+class omq_rpc final {
 
   enum class mempool_sub_type { all, blink };
   struct mempool_sub {
@@ -65,7 +65,7 @@ class omq_rpc final : public cryptonote::BlockAddedHook {
 public:
   omq_rpc(cryptonote::core& core, core_rpc_server& rpc, const boost::program_options::variables_map& vm);
 
-  bool block_added(const block& block, const std::vector<transaction>& txs, const checkpoint_t *) override;
+  void send_block_notifications(const block& block);
 
   void send_mempool_notifications(const crypto::hash& id, const transaction& tx, const std::string& blob, const tx_pool_options& opts);
 };

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -440,7 +440,7 @@ std::unique_ptr<tools::wallet2> make_basic(const boost::program_options::variabl
   try
   {
     if (!command_line::is_arg_defaulted(vm, opts.tx_notify))
-      wallet->set_tx_notify(std::shared_ptr<tools::Notify>(new tools::Notify(command_line::get_arg(vm, opts.tx_notify).c_str())));
+      wallet->set_tx_notify(std::make_shared<tools::Notify>(command_line::get_arg(vm, opts.tx_notify)));
   }
   catch (const std::exception &e)
   {
@@ -2540,9 +2540,8 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
 
   if (notify)
   {
-    std::shared_ptr<tools::Notify> tx_notify = m_tx_notify;
-    if (tx_notify)
-      tx_notify->notify("%s", tools::type_to_hex(txid).c_str(), nullptr);
+    if (auto tx_notify = m_tx_notify)
+      tx_notify->notify("%s", tools::type_to_hex(txid));
   }
 }
 //----------------------------------------------------------------------------------------------------

--- a/tests/unit_tests/checkpoints.cpp
+++ b/tests/unit_tests/checkpoints.cpp
@@ -367,7 +367,7 @@ TEST(checkpoints_blockchain_detached, detach_to_checkpoint_height)
   test_db->update_block_checkpoint(checkpoint);
 
   // NOTE: Detaching to height. Our top checkpoint should be the 1st checkpoint, we should be deleting the checkpoint at checkpoint.height
-  cp.blockchain_detached(SECOND_HEIGHT, false /*by_pop_blocks*/);
+  cp.blockchain_detached(SECOND_HEIGHT);
   checkpoint_t top_checkpoint;
   ASSERT_TRUE(test_db->get_top_checkpoint(top_checkpoint));
   ASSERT_TRUE(top_checkpoint.height == FIRST_HEIGHT);
@@ -383,7 +383,7 @@ TEST(checkpoints_blockchain_detached, detach_to_1)
   checkpoint.height += service_nodes::CHECKPOINT_INTERVAL;
   test_db->update_block_checkpoint(checkpoint);
 
-  cp.blockchain_detached(1 /*height*/, false /*by_pop_blocks*/);
+  cp.blockchain_detached(1 /*height*/);
   checkpoint_t top_checkpoint;
   ASSERT_FALSE(test_db->get_top_checkpoint(top_checkpoint));
 }

--- a/tests/unit_tests/notify.cpp
+++ b/tests/unit_tests/notify.cpp
@@ -68,8 +68,8 @@ TEST(notify, works)
 #endif
       + " " + name_template + " %s";
 
-  tools::Notify notify(spec.c_str());
-  notify.notify("%s", "1111111111111111111111111111111111111111111111111111111111111111", NULL);
+  tools::Notify notify(spec);
+  notify.notify("%s", "1111111111111111111111111111111111111111111111111111111111111111");
 
   bool ok = false;
   for (int i = 0; i < 10; ++i)


### PR DESCRIPTION
- Replaces the shoddy hook system with std::function callbacks.
- Converts the block-added and verify-miner-tx hooks to throw exceptions on error, rather than returning a bool.
- Rename block_added to block_add, because this is NOT a hook for after a block is added, but rather is a hook called while adding the block (and failing makes the block not get added).
- Add proper post-block-add hooks, and make them get used where suitable.
- Rewrite the trash tools::Notify code, and make it use a block-post-added hook rather than forcing its filth into blockchain.h.

The fourth point is important: currently there is a race condition in lokinet/SS that are using block notifications to know when to refresh the service node list, but because this was in a "block_added" hook (which really means "maybe adding a block if nothing fails") it would fire before the block is actually added, so SS/lokinet would race to fetch new block info and sometimes not actually get it (if the request got processed before the block finishes being added).  As a result, SS/lokinet would sometimes be a block behind (and sometimes not).

This fixes the race condition.