### PR TITLE
Create HWDEV file by default for hardware wallets

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -4963,12 +4963,11 @@ void wallet2::restore_from_device(const fs::path& wallet_, const epee::wipeable_
     m_subaddress_lookahead_major = 5;
     m_subaddress_lookahead_minor = 20;
   }
-  if (hwdev_label) {
-    fs::path hwdev_txt = m_wallet_file;
-    hwdev_txt += ".hwdev.txt";
-    if (!tools::dump_file(hwdev_txt, *hwdev_label))
-      MERROR("failed to write .hwdev.txt comment file");
-  }
+  fs::path hwdev_filename = m_wallet_file;
+  hwdev_filename += ".hwdev.txt";
+  std::string hwdev_text = hwdev_label.value_or("");
+  if (!tools::dump_file(hwdev_filename, hwdev_text))
+    MERROR("failed to write .hwdev.txt comment file");
   if (progress_callback)
     progress_callback(tr("Setting up account and subaddresses"));
   setup_new_blockchain();


### PR DESCRIPTION
This modifies the current behaviour from only creating the hwdev.txt
file, when a new wallet is created if content is specified as an
argument to always creating the file. This file is used by the GUI
wallet to detect if the device is a hardware device and the CLI wallet
behaviour is kept the same to keep behavious consistent between CLI and
RPC wallets.