### PR TITLE
Oxen 10.2 version bumps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,9 +51,13 @@ message(STATUS "CMake version ${CMAKE_VERSION}")
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.12 CACHE STRING "macOS deployment target (Apple clang only)")
 
 project(oxen
-    VERSION 10.1.3
+    VERSION 10.2.0
     LANGUAGES CXX C)
 set(OXEN_RELEASE_CODENAME "Wistful Wagyu")
+# Version update notes:
+# - bump the version above.
+# - for a new major release, make a new codename
+# - (if update needed) required SS/lokinet versions are in cryptonote_core/service_node_rules.h
 
 # String value to append to the full version string; this is intended to easily identify whether a
 # binary was build from the release or development branches.  This should be permanently set to an

--- a/src/cryptonote_basic/hardfork.cpp
+++ b/src/cryptonote_basic/hardfork.cpp
@@ -50,6 +50,7 @@ static constexpr std::array mainnet_hard_forks =
   hard_fork{hf::hf18,                     1,   839009, 1626217200 /*Tuesday, July 13, 2021 23:00 UTC */ }, // Oxen 9.2: mandatory SS 2.2.0 & lokinet 0.9.5 updates
   hard_fork{hf::hf19_reward_batching,     0,   1080149, 1655154000 /*Monday, June 13, 2022 21:00 UTC */}, // Oxen 10.1: Service Node Reward Batching
   hard_fork{hf::hf19_reward_batching,     1,   1090229, 1656363600 /*Monday, June 27, 2022 21:00 UTC */}, // Minor hardfork, upgrades to session.
+  hard_fork{hf::hf19_reward_batching,     2,   1146479, 1662066000 /*Wednesday, September 14, 2022 0:00 UTC */}, // Oxen 10.2: Unlock fixes, mandatory SS 2.4.0 update
 };
 
 static constexpr std::array testnet_hard_forks =
@@ -65,6 +66,7 @@ static constexpr std::array testnet_hard_forks =
   hard_fork{hf::hf18,                     0,   252,  1653632397},
   hard_fork{hf::hf19_reward_batching,     0,   253,  1653632397},
   hard_fork{hf::hf19_reward_batching,     1,   254,  1653632397}, // 2022-05-27T06:19:57.000Z UTC
+  hard_fork{hf::hf19_reward_batching,     2, 62885,  1661205699}, // 2022-08-22T22:01:39.000Z UTC
 };
 
 static constexpr std::array devnet_hard_forks =

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -995,11 +995,8 @@ namespace service_nodes
                               [&unlock](const service_node_info::contribution_t &contribution) {
                                 return unlock.key_image == contribution.key_image;
                               });
-      if (cit == contributor.locked_contributions.end())
-        return false;
-
-      if (cit->amount < small_contributor_amount_threshold && (block_height - node_info.registration_height) < service_nodes::SMALL_CONTRIBUTOR_UNLOCK_TIMER)
-        return true;
+      if (cit != contributor.locked_contributions.end())
+        return cit->amount < small_contributor_amount_threshold && (block_height - node_info.registration_height) < service_nodes::SMALL_CONTRIBUTOR_UNLOCK_TIMER;
     }
     return false;
   }

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -188,7 +188,7 @@ namespace service_nodes {
   // blocks out of sync and sending something that it thinks is legit.
   inline constexpr uint64_t VOTE_OR_TX_VERIFY_HEIGHT_BUFFER    = 5;
 
-  inline constexpr std::array<uint16_t, 3> MIN_STORAGE_SERVER_VERSION{{2, 3, 0}};
+  inline constexpr std::array<uint16_t, 3> MIN_STORAGE_SERVER_VERSION{{2, 4, 0}};
   inline constexpr std::array<uint16_t, 3> MIN_LOKINET_VERSION{{0, 9, 9}};
 
   // The minimum accepted version number, broadcasted by Service Nodes via uptime proofs for each hardfork
@@ -201,9 +201,8 @@ namespace service_nodes {
   };
 
   inline constexpr std::array MIN_UPTIME_PROOF_VERSIONS = {
+    proof_version{{cryptonote::hf::hf19_reward_batching, 2}, {10,2,0}, {0,9,9}, {2,4,0}},
     proof_version{{cryptonote::hf::hf19_reward_batching, 0}, {10,0,0}, {0,9,9}, {2,3,0}},
-    proof_version{{cryptonote::hf::hf18, 1}, {9,2,0}, {0,9,5}, {2,2,0}},
-    proof_version{{cryptonote::hf::hf18, 0}, {9,1,0}, {0,9,0}, {2,1,0}},
   };
 
   using swarm_id_t = uint64_t;


### PR DESCRIPTION
- 10.2.0 oxend version
- require lokinet 0.9.10
- require storage server 2.4.0