### PR TITLE
Add uptime proof state structure

### DIFF
--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -1193,6 +1193,10 @@ namespace cryptonote
      // avoid linking issues (protocol does not link against core).
      void* m_quorumnet_state = nullptr;
 
+     // Tracks why a node is not sending uptime proofs
+     uptime_proof::uptime_state m_uptime_state;
+
+
      /// Stores x25519 -> access level for LMQ authentication.
      /// Not to be modified after the LMQ listener starts.
      std::unordered_map<crypto::x25519_public_key, oxenmq::AuthLevel> m_omq_auth;

--- a/src/cryptonote_core/uptime_proof.cpp
+++ b/src/cryptonote_core/uptime_proof.cpp
@@ -14,6 +14,19 @@ extern "C"
 namespace uptime_proof
 {
 
+void uptime_state::set_passing()
+{
+  last_uptime_proof_check = std::chrono::steady_clock::now();
+  passing_uptime_proof = true;
+  error = static_cast<error_flag>(0);
+}
+
+void uptime_state::set_error(error_flag new_error)
+{
+  passing_uptime_proof = false;
+  error = error | new_error;
+}
+
 //Constructor for the uptime proof, will take the service node keys as a param and sign 
 Proof::Proof(
         uint32_t sn_public_ip,

--- a/src/cryptonote_core/uptime_proof.h
+++ b/src/cryptonote_core/uptime_proof.h
@@ -13,6 +13,33 @@ struct service_node_keys;
 namespace uptime_proof
 {
 
+// Keeps track of the reason why an uptime proof is not sent
+// when adding more error flags double the integer so that it will
+// BINARY OR properly
+enum error_flag
+{
+    SHARED_PRIVATE_KEY = 1,
+    NO_STORAGE_SERVER_PING = 2,
+    NO_LOKINET_PING = 4
+};
+
+inline error_flag operator|(error_flag a, error_flag b)
+{
+    return static_cast<error_flag>(static_cast<int>(a) | static_cast<int>(b));
+}
+
+class uptime_state
+{
+
+public:
+  std::chrono::steady_clock::time_point last_uptime_proof_check;
+  bool passing_uptime_proof;
+  error_flag error;
+
+  void set_error(error_flag err);
+  void set_passing();
+};
+
 class Proof
 {
   


### PR DESCRIPTION
This keeps track of the reason why a node is not sending uptime proofs.
Will allow for the user to get a more meaningful message before a
decommission of their node is made.