### PR TITLE
Update variant header from oxenmq to oxenc

### DIFF
--- a/contrib/epee/include/epee/storages/portable_storage_to_bin.h
+++ b/contrib/epee/include/epee/storages/portable_storage_to_bin.h
@@ -31,7 +31,7 @@
 #include "../pragma_comp_defs.h"
 #include "portable_storage_base.h"
 #include <oxenc/endian.h>
-#include <oxenmq/variant.h>
+#include <oxenc/variant.h>
 
 namespace epee
 {

--- a/contrib/epee/src/portable_storage.cpp
+++ b/contrib/epee/src/portable_storage.cpp
@@ -1,6 +1,6 @@
 #include "epee/storages/portable_storage_to_json.h"
 #include "epee/storages/portable_storage.h"
-#include <oxenmq/variant.h>
+#include <oxenc/variant.h>
 
 namespace epee {
   namespace serialization {

--- a/src/common/meta.h
+++ b/src/common/meta.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <string>
-#include <oxenmq/variant.h>
+#include <oxenc/variant.h>
 #include <array>
 #include <typeinfo>
 #ifdef __GNUG__

--- a/src/rpc/http_server.cpp
+++ b/src/rpc/http_server.cpp
@@ -2,7 +2,7 @@
 #include "http_server.h"
 #include <chrono>
 #include <exception>
-#include <oxenmq/variant.h>
+#include <oxenc/variant.h>
 #include "common/command_line.h"
 #include "common/string_util.h"
 #include "cryptonote_config.h"

--- a/src/serialization/boost_std_variant.h
+++ b/src/serialization/boost_std_variant.h
@@ -5,7 +5,7 @@
 // interchangeable).
 //
 
-#include <oxenmq/variant.h>
+#include <oxenc/variant.h>
 
 #include <boost/archive/archive_exception.hpp>
 

--- a/src/serialization/variant.h
+++ b/src/serialization/variant.h
@@ -36,7 +36,7 @@
  */
 #pragma once
 
-#include <oxenmq/variant.h>
+#include <oxenc/variant.h>
 #include "serialization.h"
 #include "common/meta.h"
 


### PR DESCRIPTION
The latest oxenmq dropped the long-deprecated compat header.