### PR TITLE
Archiving batching

### DIFF
--- a/src/blockchain_db/sqlite/db_sqlite.h
+++ b/src/blockchain_db/sqlite/db_sqlite.h
@@ -59,6 +59,7 @@ public:
   void increment_height();
   void decrement_height();
 
+  void blockchain_detached(uint64_t new_height);
 
   // add_sn_payments/subtract_sn_payments -> passing an array of addresses and amounts. These will be added or subtracted to the database for each address specified. If the address does not exist it will be created.
   bool add_sn_rewards(const std::vector<cryptonote::batch_sn_payment>& payments);

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -352,6 +352,9 @@ namespace config
   // If a node has been online for this amount of blocks they will receive SN rewards
   inline constexpr uint64_t SERVICE_NODE_PAYABLE_AFTER_BLOCKS = 720;
 
+  // batching and SNL will save the state every STORE_LONG_TERM_STATE_INTERVAL blocks
+  inline constexpr uint64_t STORE_LONG_TERM_STATE_INTERVAL = 10000;
+
   namespace testnet
   {
     inline constexpr uint64_t HEIGHT_ESTIMATE_HEIGHT = 339767;
@@ -451,6 +454,8 @@ struct network_config
 
   uint64_t HARDFORK_DEREGISTRATION_GRACE_PERIOD;
 
+  uint64_t STORE_LONG_TERM_STATE_INTERVAL;
+
 
   inline constexpr std::string_view governance_wallet_address(hf hard_fork_version) const {
     const auto wallet_switch =
@@ -486,6 +491,7 @@ inline constexpr network_config mainnet_config{
   config::LIMIT_BATCH_OUTPUTS,
   config::SERVICE_NODE_PAYABLE_AFTER_BLOCKS,
   config::HARDFORK_DEREGISTRATION_GRACE_PERIOD,
+  config::STORE_LONG_TERM_STATE_INTERVAL,
 };
 inline constexpr network_config testnet_config{
   network_type::TESTNET,
@@ -513,6 +519,7 @@ inline constexpr network_config testnet_config{
   config::LIMIT_BATCH_OUTPUTS,
   config::testnet::SERVICE_NODE_PAYABLE_AFTER_BLOCKS,
   config::HARDFORK_DEREGISTRATION_GRACE_PERIOD,
+  config::STORE_LONG_TERM_STATE_INTERVAL,
 };
 inline constexpr network_config devnet_config{
   network_type::DEVNET,
@@ -567,6 +574,7 @@ inline constexpr network_config fakenet_config{
   config::LIMIT_BATCH_OUTPUTS,
   config::testnet::SERVICE_NODE_PAYABLE_AFTER_BLOCKS,
   config::HARDFORK_DEREGISTRATION_GRACE_PERIOD,
+  config::STORE_LONG_TERM_STATE_INTERVAL,
 };
 
 inline constexpr const network_config& get_config(network_type nettype)

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -726,8 +726,6 @@ void Blockchain::pop_blocks(uint64_t nblocks)
   detached_info hook_data{m_db->height(), /*by_pop_blocks=*/true};
   for (const auto& hook : m_blockchain_detached_hooks)
     hook(hook_data);
-  if (!pop_batching_rewards)
-    m_service_node_list.reset_batching_to_latest_height();
   load_missing_blocks_into_oxen_subsystems();
 
   if (stop_batch)

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -765,6 +765,8 @@ namespace cryptonote
     m_blockchain_storage.hook_init([this] { m_service_node_list.init(); });
     m_blockchain_storage.hook_validate_miner_tx([this] (const auto& info) { m_service_node_list.validate_miner_tx(info); });
     m_blockchain_storage.hook_alt_block_add([this] (const auto& info) { m_service_node_list.alt_block_add(info); });
+    
+    m_blockchain_storage.hook_blockchain_detached([this] (const auto& info) { m_blockchain_storage.sqlite_db()->blockchain_detached(info.height); });
 
     // NOTE: There is an implicit dependency on service node lists being hooked first!
     m_blockchain_storage.hook_init([this] { m_quorum_cop.init(); });

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1759,17 +1759,12 @@ namespace service_nodes
     }
   }
 
-  void service_node_list::reset_batching_to_latest_height()
-  {
-    m_blockchain.sqlite_db()->reset_database();
-    m_blockchain.sqlite_db()->update_height(0);
-  }
-
   bool service_node_list::state_history_exists(uint64_t height)
   {
     auto it = m_transient.state_history.find(height);
     return it != m_transient.state_history.end();
   }
+
 
   bool service_node_list::process_batching_rewards(const cryptonote::block& block)
   {

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -456,7 +456,6 @@ namespace service_nodes
     service_node_list &operator=(const service_node_list &) = delete;
 
     void block_add(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs, const cryptonote::checkpoint_t* checkpoint);
-    void reset_batching_to_latest_height();
     bool state_history_exists(uint64_t height);
     bool process_batching_rewards(const cryptonote::block& block);
     bool pop_batching_rewards_block(const cryptonote::block& block);


### PR DESCRIPTION
This adds a new table to the batching schema to copy the accrued balances every so often. This means that we can jump back to a previous point without popping blocks.

The archiving is triggered in sql every 100 blocks and added to the archive table, then pruned from the archive table at a later time to ensure the size is kept small. Rebuilding 100 blocks is pretty reasonable and should be less than 10s.

For longer distance pop_blocks and blockchain detached every 10k blocks is kept in the archiving table. This takes longer to rebuild but is better than rebuilding from scratch.

The blockchain detached function is also added to our regular blockchain detached hooks so that it gets called every time the blockchain detaches. Which appears to have caused some issues previously when some of the modules would detach but batching would be stuck in an advanced state.