### PR TITLE
Disable logging to stdout for wallet2

### DIFF
--- a/src/logging/oxen_logger.cpp
+++ b/src/logging/oxen_logger.cpp
@@ -78,11 +78,18 @@ namespace oxen::logging
   }
 
   void
-  init(const std::string& log_location, log::Level log_level)
+  init(const std::string& log_location, log::Level log_level, bool log_to_stdout)
   {
     log::reset_level(log_level);
-    log::add_sink(log::Type::Print, "stdout");
+    if (log_to_stdout)
+      log::add_sink(log::Type::Print, "stdout");
+    set_file_sink(log_location);
+    set_additional_log_categories(log_level);
+  }
 
+  void
+  set_file_sink(const std::string& log_location)
+  {
     constexpr size_t LOG_FILE_SIZE_LIMIT = 1024 * 1024 * 50;  // 50MiB
     constexpr size_t EXTRA_FILES = 1;
 
@@ -105,8 +112,6 @@ namespace oxen::logging
           ex.what());
       return;
     }
-
-    set_additional_log_categories(log_level);
 
     log::info(logcat, "Writing logs to {}", log_location);
   }

--- a/src/logging/oxen_logger.h
+++ b/src/logging/oxen_logger.h
@@ -20,7 +20,9 @@ inline auto globallogcat = oxen::log::Cat("global");
 namespace oxen::logging
 {
   void
-  init(const std::string& log_location, log::Level log_level);
+  init(const std::string& log_location, log::Level log_level, bool log_to_stdout = true);
+  void
+  set_file_sink(const std::string& log_location);
   void
   set_additional_log_categories(const log::Level& log_level);
   void

--- a/src/wallet/wallet_args.cpp
+++ b/src/wallet/wallet_args.cpp
@@ -189,7 +189,7 @@ namespace wallet_args
         throw std::runtime_error{"Incorrect log level"};
     }
 
-    oxen::logging::init(log_path, log_level);
+    oxen::logging::init(log_path, log_level, false /*do not log to stdout.*/);
 
     if (notice)
       print("{}\n"_format(notice));


### PR DESCRIPTION
The logging refactor brought in some changes to how the logs are created and as a result logs were polluting the command line where wallet2 was displaying information. This makes the logging for wallet only to file and stdout is reserved to the wallet to communicate to the user.