### PR TITLE
Change gcc visibility flag to default for wallet_api

### DIFF
--- a/src/wallet/api/CMakeLists.txt
+++ b/src/wallet/api/CMakeLists.txt
@@ -53,6 +53,7 @@ target_link_libraries(wallet_api
     extra)
 
 set_property(TARGET wallet_api PROPERTY EXCLUDE_FROM_ALL TRUE)
+target_compile_options(wallet_api PRIVATE -fvisibility=default)
 
 if(IOS)
     set(lib_folder lib-${ARCH})

--- a/src/wallet/api/address_book.cpp
+++ b/src/wallet/api/address_book.cpp
@@ -39,14 +39,11 @@
 
 namespace Wallet {
 
-EXPORT
 AddressBook::~AddressBook() {}
 
-EXPORT
 AddressBookImpl::AddressBookImpl(WalletImpl *wallet)
     : m_wallet(wallet), m_errorCode(Status_Ok) {}
 
-EXPORT
 bool AddressBookImpl::addRow(const std::string &dst_addr, const std::string &description)
 {
   clearStatus();
@@ -67,7 +64,6 @@ bool AddressBookImpl::addRow(const std::string &dst_addr, const std::string &des
   return r;
 }
 
-EXPORT
 void AddressBookImpl::refresh() 
 {
   log::debug(logcat, "Refreshing addressbook");
@@ -90,7 +86,6 @@ void AddressBookImpl::refresh()
   
 }
 
-EXPORT
 bool AddressBookImpl::deleteRow(std::size_t rowId)
 {
   log::debug(logcat, "Deleting address book row {}", rowId);
@@ -100,7 +95,6 @@ bool AddressBookImpl::deleteRow(std::size_t rowId)
   return r;
 } 
 
-EXPORT
 void AddressBookImpl::clearRows() {
    for (auto r : m_rows) {
      delete r;
@@ -108,20 +102,17 @@ void AddressBookImpl::clearRows() {
    m_rows.clear();
 }
 
-EXPORT
 void AddressBookImpl::clearStatus(){
   m_errorString = "";
   m_errorCode = 0;
 }
 
-EXPORT
 std::vector<AddressBookRow*> AddressBookImpl::getAll() const
 {
   return m_rows;
 }
 
 
-EXPORT
 AddressBookImpl::~AddressBookImpl()
 {
   clearRows();

--- a/src/wallet/api/common_defines.h
+++ b/src/wallet/api/common_defines.h
@@ -1,9 +1,3 @@
 #pragma once
 
 #define tr(x) (x)
-
-#ifdef __GNUC__
-#define EXPORT __attribute__((visibility("default"))) __attribute__((used))
-#else
-#define EXPORT
-#endif

--- a/src/wallet/api/pending_transaction.cpp
+++ b/src/wallet/api/pending_transaction.cpp
@@ -43,33 +43,27 @@
 
 namespace Wallet {
 
-EXPORT
 PendingTransaction::~PendingTransaction() {}
 
 
-EXPORT
 PendingTransactionImpl::PendingTransactionImpl(WalletImpl &wallet)
     : m_wallet(wallet), m_status{Status_Ok, ""}
 {
 }
 
-EXPORT
 PendingTransactionImpl::PendingTransactionImpl(WalletImpl& wallet, std::vector<tools::wallet2::pending_tx> pending_tx)
     : m_wallet{wallet}, m_status{Status_Ok, ""}, m_pending_tx{std::move(pending_tx)}
 {}
 
-EXPORT
 PendingTransactionImpl::~PendingTransactionImpl()
 {
 
 }
 
-EXPORT
 void PendingTransactionImpl::setError(std::string error_msg) {
   m_status = {Status_Error, tr(error_msg)};
 }
 
-EXPORT
 std::vector<std::string> PendingTransactionImpl::txid() const
 {
     std::vector<std::string> txid;
@@ -78,7 +72,6 @@ std::vector<std::string> PendingTransactionImpl::txid() const
     return txid;
 }
 
-EXPORT
 bool PendingTransactionImpl::commit(std::string_view filename_, bool overwrite, bool blink)
 {
 
@@ -152,7 +145,6 @@ bool PendingTransactionImpl::commit(std::string_view filename_, bool overwrite, 
     return good();
 }
 
-EXPORT
 uint64_t PendingTransactionImpl::amount() const
 {
     uint64_t result = 0;
@@ -175,7 +167,6 @@ uint64_t PendingTransactionImpl::amount() const
     return result;
 }
 
-EXPORT
 uint64_t PendingTransactionImpl::dust() const
 {
     uint64_t result = 0;
@@ -185,7 +176,6 @@ uint64_t PendingTransactionImpl::dust() const
     return result;
 }
 
-EXPORT
 uint64_t PendingTransactionImpl::fee() const
 {
     uint64_t result = 0;
@@ -195,13 +185,11 @@ uint64_t PendingTransactionImpl::fee() const
     return result;
 }
 
-EXPORT
 uint64_t PendingTransactionImpl::txCount() const
 {
     return m_pending_tx.size();
 }
 
-EXPORT
 std::vector<uint32_t> PendingTransactionImpl::subaddrAccount() const
 {
     std::vector<uint32_t> result;
@@ -210,7 +198,6 @@ std::vector<uint32_t> PendingTransactionImpl::subaddrAccount() const
     return result;
 }
 
-EXPORT
 std::vector<std::set<uint32_t>> PendingTransactionImpl::subaddrIndices() const
 {
     std::vector<std::set<uint32_t>> result;
@@ -219,7 +206,6 @@ std::vector<std::set<uint32_t>> PendingTransactionImpl::subaddrIndices() const
     return result;
 }
 
-EXPORT
 std::string PendingTransactionImpl::multisigSignData() {
     try {
         if (!m_wallet.multisig().isMultisig) {
@@ -239,7 +225,6 @@ std::string PendingTransactionImpl::multisigSignData() {
     return std::string();
 }
 
-EXPORT
 void PendingTransactionImpl::signMultisigTx() {
     try {
         std::vector<crypto::hash> ignore;
@@ -259,7 +244,6 @@ void PendingTransactionImpl::signMultisigTx() {
     }
 }
 
-EXPORT
 std::vector<std::string> PendingTransactionImpl::signersKeys() const {
     std::vector<std::string> keys;
     keys.reserve(m_signers.size());

--- a/src/wallet/api/stake_unlock_result.cpp
+++ b/src/wallet/api/stake_unlock_result.cpp
@@ -4,34 +4,29 @@
 
 namespace Wallet {
 
-EXPORT
 StakeUnlockResultImpl::StakeUnlockResultImpl(WalletImpl& w, tools::wallet2::request_stake_unlock_result res)
     : wallet{w}, result(std::move(res))
 {
 }
 
-EXPORT
 StakeUnlockResultImpl::~StakeUnlockResultImpl()
 {
     log::trace(logcat, "Stake Unlock Result Deleted");
 }
 
 //----------------------------------------------------------------------------------------------------
-EXPORT
 bool StakeUnlockResultImpl::success()
 {
     return result.success;
 }
 
 //----------------------------------------------------------------------------------------------------
-EXPORT
 std::string StakeUnlockResultImpl::msg()
 {
     return result.msg;
 }
 
 //----------------------------------------------------------------------------------------------------
-EXPORT
 PendingTransaction* StakeUnlockResultImpl::ptx()
 {
     return new PendingTransactionImpl{wallet, {{result.ptx}}};

--- a/src/wallet/api/subaddress.cpp
+++ b/src/wallet/api/subaddress.cpp
@@ -36,21 +36,17 @@
 
 namespace Wallet {
   
-EXPORT
 Subaddress::~Subaddress() {}
   
-EXPORT
 SubaddressImpl::SubaddressImpl(WalletImpl *wallet)
     : m_wallet(wallet) {}
 
-EXPORT
 void SubaddressImpl::addRow(uint32_t accountIndex, const std::string &label)
 {
   m_wallet->wallet()->add_subaddress(accountIndex, label);
   refresh(accountIndex);
 }
 
-EXPORT
 void SubaddressImpl::setLabel(uint32_t accountIndex, uint32_t addressIndex, const std::string &label)
 {
   try
@@ -64,7 +60,6 @@ void SubaddressImpl::setLabel(uint32_t accountIndex, uint32_t addressIndex, cons
   }
 }
 
-EXPORT
 void SubaddressImpl::refresh(uint32_t accountIndex) 
 {
   log::debug(logcat, "Refreshing subaddress");
@@ -77,7 +72,6 @@ void SubaddressImpl::refresh(uint32_t accountIndex)
   }
 }
 
-EXPORT
 void SubaddressImpl::clearRows() {
    for (auto r : m_rows) {
      delete r;
@@ -85,13 +79,11 @@ void SubaddressImpl::clearRows() {
    m_rows.clear();
 }
 
-EXPORT
 std::vector<SubaddressRow*> SubaddressImpl::getAll() const
 {
   return m_rows;
 }
 
-EXPORT
 SubaddressImpl::~SubaddressImpl()
 {
   clearRows();

--- a/src/wallet/api/subaddress_account.cpp
+++ b/src/wallet/api/subaddress_account.cpp
@@ -36,28 +36,23 @@
 
 namespace Wallet {
   
-EXPORT
 SubaddressAccount::~SubaddressAccount() {}
   
-EXPORT
 SubaddressAccountImpl::SubaddressAccountImpl(WalletImpl *wallet)
     : m_wallet(wallet) {}
 
-EXPORT
 void SubaddressAccountImpl::addRow(const std::string &label)
 {
   m_wallet->wallet()->add_subaddress_account(label);
   refresh();
 }
 
-EXPORT
 void SubaddressAccountImpl::setLabel(uint32_t accountIndex, const std::string &label)
 {
   m_wallet->wallet()->set_subaddress_label({accountIndex, 0}, label);
   refresh();
 }
 
-EXPORT
 void SubaddressAccountImpl::refresh() 
 {
   log::debug(logcat, "Refreshing subaddress account");
@@ -76,7 +71,6 @@ void SubaddressAccountImpl::refresh()
   }
 }
 
-EXPORT
 void SubaddressAccountImpl::clearRows() {
    for (auto r : m_rows) {
      delete r;
@@ -84,13 +78,11 @@ void SubaddressAccountImpl::clearRows() {
    m_rows.clear();
 }
 
-EXPORT
 std::vector<SubaddressAccountRow*> SubaddressAccountImpl::getAll() const
 {
   return m_rows;
 }
 
-EXPORT
 SubaddressAccountImpl::~SubaddressAccountImpl()
 {
   clearRows();

--- a/src/wallet/api/transaction_history.cpp
+++ b/src/wallet/api/transaction_history.cpp
@@ -43,25 +43,21 @@
 
 namespace Wallet {
 
-EXPORT
 TransactionHistory::~TransactionHistory() {}
 
 
-EXPORT
 TransactionHistoryImpl::TransactionHistoryImpl(WalletImpl *wallet)
     : m_wallet(wallet)
 {
 
 }
 
-EXPORT
 TransactionHistoryImpl::~TransactionHistoryImpl()
 {
     for (auto t : m_history)
         delete t;
 }
 
-EXPORT
 int TransactionHistoryImpl::count() const
 {
     std::shared_lock lock{m_historyMutex};
@@ -69,7 +65,6 @@ int TransactionHistoryImpl::count() const
     return result;
 }
 
-EXPORT
 TransactionInfo *TransactionHistoryImpl::transaction(int index) const
 {
     std::shared_lock lock{m_historyMutex};
@@ -80,7 +75,6 @@ TransactionInfo *TransactionHistoryImpl::transaction(int index) const
     return index_ < m_history.size() ? m_history[index_] : nullptr;
 }
 
-EXPORT
 TransactionInfo *TransactionHistoryImpl::transaction(std::string_view id) const
 {
     std::shared_lock lock{m_historyMutex};
@@ -91,7 +85,6 @@ TransactionInfo *TransactionHistoryImpl::transaction(std::string_view id) const
     return itr != m_history.end() ? *itr : nullptr;
 }
 
-EXPORT
 std::vector<TransactionInfo *> TransactionHistoryImpl::getAll() const
 {
     std::shared_lock lock{m_historyMutex};
@@ -106,7 +99,6 @@ static reward_type from_pay_type(wallet::pay_type ptype) {
     }
 }
 
-EXPORT
 void TransactionHistoryImpl::refresh()
 {
     // multithreaded access:

--- a/src/wallet/api/transaction_info.cpp
+++ b/src/wallet/api/transaction_info.cpp
@@ -34,15 +34,12 @@
 
 namespace Wallet {
 
-EXPORT
 TransactionInfo::~TransactionInfo() {}
 
-EXPORT
 TransactionInfo::Transfer::Transfer(uint64_t _amount, std::string _address)
     : amount(_amount), address(std::move(_address)) {}
 
 
-EXPORT
 TransactionInfoImpl::TransactionInfoImpl()
     : m_direction(Direction_Out)
       , m_pending(false)
@@ -60,116 +57,97 @@ TransactionInfoImpl::TransactionInfoImpl()
 
 }
 
-EXPORT
 TransactionInfoImpl::~TransactionInfoImpl()
 {
 
 }
 
-EXPORT
 int TransactionInfoImpl::direction() const
 {
     return m_direction;
 }
 
-EXPORT
 bool TransactionInfoImpl::isServiceNodeReward() const
 {
     return m_reward_type == reward_type::service_node;
 }
 
-EXPORT
 bool TransactionInfoImpl::isMinerReward() const
 {
     return m_reward_type == reward_type::miner;
 }
 
-EXPORT
 bool TransactionInfoImpl::isStake() const
 {
     return m_is_stake;
 }
 
-EXPORT
 bool TransactionInfoImpl::isPending() const
 {
     return m_pending;
 }
 
-EXPORT
 bool TransactionInfoImpl::isFailed() const
 {
     return m_failed;
 }
 
-EXPORT
 uint64_t TransactionInfoImpl::amount() const
 {
     return m_amount;
 }
 
-EXPORT
 uint64_t TransactionInfoImpl::fee() const
 {
     return m_fee;
 }
 
-EXPORT
 uint64_t TransactionInfoImpl::blockHeight() const
 {
     return m_blockheight;
 }
 
-EXPORT
 std::set<uint32_t> TransactionInfoImpl::subaddrIndex() const
 {
     return m_subaddrIndex;
 }
 
-EXPORT
 uint32_t TransactionInfoImpl::subaddrAccount() const
 {
     return m_subaddrAccount;
 }
 
-EXPORT
 std::string TransactionInfoImpl::label() const
 {
     return m_label;
 }
 
 
-EXPORT
 std::string TransactionInfoImpl::hash() const
 {
     return m_hash;
 }
 
-EXPORT
 std::time_t TransactionInfoImpl::timestamp() const
 {
     return m_timestamp;
 }
 
-EXPORT
 std::string TransactionInfoImpl::paymentId() const
 {
     return m_paymentid;
 }
 
-EXPORT
 const std::vector<TransactionInfo::Transfer> &TransactionInfoImpl::transfers() const
 {
     return m_transfers;
 }
 
-EXPORT
 uint64_t TransactionInfoImpl::confirmations() const
 {
     return m_confirmations;
 }
 
-EXPORT
 uint64_t TransactionInfoImpl::unlockTime() const
 {
     return m_unlock_time;

--- a/src/wallet/api/unsigned_transaction.cpp
+++ b/src/wallet/api/unsigned_transaction.cpp
@@ -41,23 +41,19 @@
 
 namespace Wallet {
 
-EXPORT
 UnsignedTransaction::~UnsignedTransaction() {}
 
 
-EXPORT
 UnsignedTransactionImpl::UnsignedTransactionImpl(WalletImpl &wallet)
     : m_wallet(wallet), m_status{Status_Ok, ""}
 {
 }
 
-EXPORT
 UnsignedTransactionImpl::~UnsignedTransactionImpl()
 {
     log::trace(logcat, "Unsigned tx deleted");
 }
 
-EXPORT
 bool UnsignedTransactionImpl::sign(std::string_view signedFileName_)
 {
   auto signedFileName = fs::u8path(signedFileName_);
@@ -85,7 +81,6 @@ bool UnsignedTransactionImpl::sign(std::string_view signedFileName_)
 }
 
 //----------------------------------------------------------------------------------------------------
-EXPORT
 bool UnsignedTransactionImpl::checkLoadedTx(const std::function<size_t()> get_num_txes, const std::function<const wallet::tx_construction_data&(size_t)> &get_tx, const std::string &extra_message)
 {
   // gather info to ask the user
@@ -202,7 +197,6 @@ bool UnsignedTransactionImpl::checkLoadedTx(const std::function<size_t()> get_nu
   return true;
 }
 
-EXPORT
 std::vector<uint64_t> UnsignedTransactionImpl::amount() const
 {
     std::vector<uint64_t> result;
@@ -214,7 +208,6 @@ std::vector<uint64_t> UnsignedTransactionImpl::amount() const
     return result;
 }
 
-EXPORT
 std::vector<uint64_t> UnsignedTransactionImpl::fee() const
 {
     std::vector<uint64_t> result;
@@ -227,7 +220,6 @@ std::vector<uint64_t> UnsignedTransactionImpl::fee() const
     return result;
 } 
 
-EXPORT
 std::vector<uint64_t> UnsignedTransactionImpl::mixin() const
 {
     std::vector<uint64_t> result;    
@@ -244,13 +236,11 @@ std::vector<uint64_t> UnsignedTransactionImpl::mixin() const
     return result;
 }    
 
-EXPORT
 uint64_t UnsignedTransactionImpl::txCount() const
 {
     return m_unsigned_tx_set.txes.size();
 }
 
-EXPORT
 std::vector<std::string> UnsignedTransactionImpl::paymentId() const 
 {
     std::vector<std::string> result;
@@ -280,7 +270,6 @@ std::vector<std::string> UnsignedTransactionImpl::paymentId() const
     return result;
 }
 
-EXPORT
 std::vector<std::string> UnsignedTransactionImpl::recipientAddress() const 
 {
     // TODO: return integrated address if short payment ID exists
@@ -295,7 +284,6 @@ std::vector<std::string> UnsignedTransactionImpl::recipientAddress() const
     return result;
 }
 
-EXPORT
 uint64_t UnsignedTransactionImpl::minMixinCount() const
 {    
     uint64_t min_mixin = ~0;  

--- a/src/wallet/api/utils.cpp
+++ b/src/wallet/api/utils.cpp
@@ -35,7 +35,6 @@
 namespace Wallet {
 namespace Utils {
 
-EXPORT
 bool isAddressLocal(const std::string &address)
 { 
     try {
@@ -46,7 +45,6 @@ bool isAddressLocal(const std::string &address)
     }
 }
 
-EXPORT
 void onStartup()
 {
     tools::on_startup();

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -108,7 +108,6 @@ namespace {
 struct Wallet2CallbackImpl : public tools::i_wallet2_callback
 {
 
-    EXPORT
     Wallet2CallbackImpl(WalletImpl * wallet)
      : m_listener(nullptr)
      , m_wallet(wallet)
@@ -116,25 +115,21 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
 
     }
 
-    EXPORT
     ~Wallet2CallbackImpl()
     {
 
     }
 
-    EXPORT
     void setListener(WalletListener * listener)
     {
         m_listener = listener;
     }
 
-    EXPORT
     WalletListener * getListener() const
     {
         return m_listener;
     }
 
-    EXPORT
     void on_new_block(uint64_t height, const cryptonote::block& block) override
     {
         // Don't flood the GUI with signals. On fast refresh - send signal every 1000th block
@@ -149,7 +144,6 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
         }
     }
 
-    EXPORT
     void on_money_received(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& tx, uint64_t amount, const cryptonote::subaddress_index& subaddr_index, uint64_t unlock_time, bool blink) override
     {
         std::string tx_hash = tools::type_to_hex(txid);
@@ -162,7 +156,6 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
         }
     }
 
-    EXPORT
     void on_unconfirmed_money_received(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& tx, uint64_t amount, const cryptonote::subaddress_index& subaddr_index) override
     {
 
@@ -176,7 +169,6 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
         }
     }
 
-    EXPORT
     void on_money_spent(uint64_t height,
                         const crypto::hash &txid,
                         const cryptonote::transaction &in_tx,
@@ -194,14 +186,12 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
         }
     }
 
-    EXPORT
     void on_skip_transaction(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& tx) override
     {
         // TODO;
     }
 
     // Light wallet callbacks
-    EXPORT
     void on_lw_new_block(uint64_t height) override
     {
       if (m_listener) {
@@ -209,7 +199,6 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
       }
     }
 
-    EXPORT
     void on_lw_money_received(uint64_t height, const crypto::hash &txid, uint64_t amount) override
     {
       if (m_listener) {
@@ -218,7 +207,6 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
       }
     }
 
-    EXPORT
     void on_lw_unconfirmed_money_received(uint64_t height, const crypto::hash &txid, uint64_t amount) override
     {
       if (m_listener) {
@@ -227,7 +215,6 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
       }
     }
 
-    EXPORT
     void on_lw_money_spent(uint64_t height, const crypto::hash &txid, uint64_t amount) override
     {
       if (m_listener) {
@@ -236,7 +223,6 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
       }
     }
 
-    EXPORT
     void on_device_button_request(uint64_t code) override
     {
       if (m_listener) {
@@ -244,7 +230,6 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
       }
     }
 
-    EXPORT
     void on_device_button_pressed() override
     {
       if (m_listener) {
@@ -252,7 +237,6 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
       }
     }
 
-    EXPORT
     std::optional<epee::wipeable_string> on_device_pin_request() override
     {
       if (m_listener) {
@@ -264,7 +248,6 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
       return std::nullopt;
     }
 
-    EXPORT
     std::optional<epee::wipeable_string> on_device_passphrase_request(bool& on_device) override
     {
       if (m_listener) {
@@ -278,7 +261,6 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
       return std::nullopt;
     }
 
-    EXPORT
     void on_device_progress(const hw::device_progress & event) override
     {
       if (m_listener) {
@@ -290,26 +272,21 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
     WalletImpl     * m_wallet;
 };
 
-EXPORT
 Wallet::~Wallet() {}
 
-EXPORT
 WalletListener::~WalletListener() {}
 
 
-EXPORT
 std::string Wallet::displayAmount(uint64_t amount)
 {
     return cryptonote::print_money(amount);
 }
 
-EXPORT
 uint64_t Wallet::amountFromString(const std::string &amount)
 {
     return cryptonote::parse_amount(amount).value_or(0);
 }
 
-EXPORT
 uint64_t Wallet::amountFromDouble(double amount)
 {
     std::stringstream ss;
@@ -317,7 +294,6 @@ uint64_t Wallet::amountFromDouble(double amount)
     return amountFromString(ss.str());
 }
 
-EXPORT
 std::string Wallet::genPaymentId()
 {
     crypto::hash8 payment_id = crypto::rand<crypto::hash8>();
@@ -325,27 +301,23 @@ std::string Wallet::genPaymentId()
 
 }
 
-EXPORT
 bool Wallet::paymentIdValid(const std::string &payment_id)
 {
     return payment_id.size() == 16 && oxenc::is_hex(payment_id);
 }
 
-EXPORT
 bool Wallet::serviceNodePubkeyValid(const std::string &str)
 {
     crypto::public_key sn_key;
     return str.size() == 64 && oxenc::is_hex(str);
 }
 
-EXPORT
 bool Wallet::addressValid(const std::string &str, NetworkType nettype)
 {
   cryptonote::address_parse_info info;
   return get_account_address_from_str(info, static_cast<cryptonote::network_type>(nettype), str);
 }
 
-EXPORT
 bool Wallet::keyValid(const std::string &secret_key_string, const std::string &address_string, bool isViewKey, NetworkType nettype, std::string &error)
 {
   cryptonote::address_parse_info info;
@@ -381,7 +353,6 @@ bool Wallet::keyValid(const std::string &secret_key_string, const std::string &a
   return true;
 }
 
-EXPORT
 std::string Wallet::paymentIdFromAddress(const std::string &str, NetworkType nettype)
 {
   cryptonote::address_parse_info info;
@@ -392,19 +363,16 @@ std::string Wallet::paymentIdFromAddress(const std::string &str, NetworkType net
   return tools::type_to_hex(info.payment_id);
 }
 
-EXPORT
 uint64_t Wallet::maximumAllowedAmount()
 {
     return std::numeric_limits<uint64_t>::max();
 }
 
-EXPORT
 void Wallet::init(const char *argv0, const char *default_log_base_name, const std::string& log_path, bool console) {
     epee::string_tools::set_module_name_and_folder(argv0);
     oxen::logging::init(log_path.empty() ? default_log_base_name : log_path, log::Level::info);
 }
 
-EXPORT
 void Wallet::debug(const std::string &category, const std::string &str) {
     if (category.empty())
       log::debug(logcat, str);
@@ -412,7 +380,6 @@ void Wallet::debug(const std::string &category, const std::string &str) {
       log::debug(log::Cat(category), str);
 }
 
-EXPORT
 void Wallet::info(const std::string &category, const std::string &str) {
     if (category.empty())
       log::info(logcat, str);
@@ -420,7 +387,6 @@ void Wallet::info(const std::string &category, const std::string &str) {
       log::info(log::Cat(category), str);
 }
 
-EXPORT
 void Wallet::warning(const std::string &category, const std::string &str) {
     if (category.empty())
       log::warning(logcat, str);
@@ -428,7 +394,6 @@ void Wallet::warning(const std::string &category, const std::string &str) {
       log::warning(log::Cat(category), str);
 }
 
-EXPORT
 void Wallet::error(const std::string &category, const std::string &str) {
     if (category.empty())
       log::error(logcat, str);
@@ -437,7 +402,6 @@ void Wallet::error(const std::string &category, const std::string &str) {
 }
 
 ///////////////////////// WalletImpl implementation ////////////////////////
-EXPORT
 WalletImpl::WalletImpl(NetworkType nettype, uint64_t kdf_rounds)
     :m_wallet_ptr(nullptr)
     , m_status(Wallet::Status_Ok, "")
@@ -479,7 +443,6 @@ WalletImpl::WalletImpl(NetworkType nettype, uint64_t kdf_rounds)
     });
 }
 
-EXPORT
 WalletImpl::~WalletImpl()
 {
 
@@ -501,7 +464,6 @@ WalletImpl::~WalletImpl()
     log::info(logcat, "{} finished", __FUNCTION__);
 }
 
-EXPORT
 bool WalletImpl::create(std::string_view path_, const std::string &password, const std::string &language)
 {
 
@@ -539,7 +501,6 @@ bool WalletImpl::create(std::string_view path_, const std::string &password, con
     return true;
 }
 
-EXPORT
 bool WalletImpl::createWatchOnly(std::string_view path_, const std::string &password, const std::string &language) const
 {
     auto path = fs::u8path(path_);
@@ -607,7 +568,6 @@ bool WalletImpl::createWatchOnly(std::string_view path_, const std::string &pass
     return true;
 }
 
-EXPORT
 bool WalletImpl::recoverFromKeysWithPassword(std::string_view path_,
                                  const std::string &password,
                                  const std::string &language,
@@ -699,7 +659,6 @@ bool WalletImpl::recoverFromKeysWithPassword(std::string_view path_,
     return true;
 }
 
-EXPORT
 bool WalletImpl::recoverFromDevice(std::string_view path_, const std::string &password, const std::string &device_name)
 {
     auto path = fs::u8path(path_);
@@ -719,13 +678,11 @@ bool WalletImpl::recoverFromDevice(std::string_view path_, const std::string &pa
     return true;
 }
 
-EXPORT
 Wallet::Device WalletImpl::getDeviceType() const
 {
     return static_cast<Wallet::Device>(m_wallet_ptr->get_device_type());
 }
 
-EXPORT
 bool WalletImpl::open(std::string_view path_, const std::string &password)
 {
     auto path = fs::u8path(path_);
@@ -754,7 +711,6 @@ bool WalletImpl::open(std::string_view path_, const std::string &password)
     return good();
 }
 
-EXPORT
 bool WalletImpl::recover(std::string_view path_, const std::string &password, const std::string &seed, const std::string &seed_offset/* = {}*/)
 {
     auto path = fs::u8path(path_);
@@ -792,7 +748,6 @@ bool WalletImpl::recover(std::string_view path_, const std::string &password, co
     return good();
 }
 
-EXPORT
 bool WalletImpl::close(bool store)
 {
 
@@ -822,7 +777,6 @@ bool WalletImpl::close(bool store)
     return result;
 }
 
-EXPORT
 std::string WalletImpl::seed() const
 {
     epee::wipeable_string seed;
@@ -831,30 +785,25 @@ std::string WalletImpl::seed() const
     return std::string(seed.data(), seed.size()); // TODO
 }
 
-EXPORT
 std::string WalletImpl::getSeedLanguage() const
 {
     return wallet()->get_seed_language();
 }
 
-EXPORT
 void WalletImpl::setSeedLanguage(const std::string &arg)
 {
     wallet()->set_seed_language(arg);
 }
 
-EXPORT
 std::pair<int, std::string> WalletImpl::status() const {
     std::lock_guard l{m_statusMutex};
     return m_status;
 }
-EXPORT
 bool WalletImpl::good() const {
     std::lock_guard l{m_statusMutex};
     return m_status.first == Status_Ok;
 }
 
-EXPORT
 bool WalletImpl::setPassword(const std::string &password)
 {
     clearStatus();
@@ -868,7 +817,6 @@ bool WalletImpl::setPassword(const std::string &password)
     return good();
 }
 
-EXPORT
 bool WalletImpl::setDevicePin(const std::string &pin)
 {
     clearStatus();
@@ -880,7 +828,6 @@ bool WalletImpl::setDevicePin(const std::string &pin)
     return good();
 }
 
-EXPORT
 bool WalletImpl::setDevicePassphrase(const std::string &passphrase)
 {
     clearStatus();
@@ -892,13 +839,11 @@ bool WalletImpl::setDevicePassphrase(const std::string &passphrase)
     return good();
 }
 
-EXPORT
 std::string WalletImpl::address(uint32_t accountIndex, uint32_t addressIndex) const
 {
     return wallet()->get_subaddress_as_str({accountIndex, addressIndex});
 }
 
-EXPORT
 std::string WalletImpl::integratedAddress(const std::string &payment_id) const
 {
     crypto::hash8 pid;
@@ -907,31 +852,26 @@ std::string WalletImpl::integratedAddress(const std::string &payment_id) const
     return wallet()->get_integrated_address_as_str(pid);
 }
 
-EXPORT
 std::string WalletImpl::secretViewKey() const
 {
     return tools::type_to_hex(wallet()->get_account().get_keys().m_view_secret_key);
 }
 
-EXPORT
 std::string WalletImpl::publicViewKey() const
 {
     return tools::type_to_hex(wallet()->get_account().get_keys().m_account_address.m_view_public_key);
 }
 
-EXPORT
 std::string WalletImpl::secretSpendKey() const
 {
     return tools::type_to_hex(wallet()->get_account().get_keys().m_spend_secret_key);
 }
 
-EXPORT
 std::string WalletImpl::publicSpendKey() const
 {
     return tools::type_to_hex(wallet()->get_account().get_keys().m_account_address.m_spend_public_key);
 }
 
-EXPORT
 std::string WalletImpl::publicMultisigSignerKey() const
 {
     try {
@@ -942,13 +882,11 @@ std::string WalletImpl::publicMultisigSignerKey() const
     }
 }
 
-EXPORT
 std::string WalletImpl::path() const
 {
     return wallet()->path().u8string();
 }
 
-EXPORT
 bool WalletImpl::store(std::string_view path_)
 {
     auto path = fs::u8path(path_);
@@ -968,19 +906,16 @@ bool WalletImpl::store(std::string_view path_)
     return true;
 }
 
-EXPORT
 std::string WalletImpl::filename() const
 {
     return wallet()->get_wallet_file().u8string();
 }
 
-EXPORT
 std::string WalletImpl::keysFilename() const
 {
     return wallet()->get_keys_file().u8string();
 }
 
-EXPORT
 bool WalletImpl::init(const std::string &daemon_address, uint64_t upper_transaction_size_limit, const std::string &daemon_username, const std::string &daemon_password, bool use_ssl ENABLE_IF_LIGHT_WALLET(, bool lightWallet))
 {
     clearStatus();
@@ -993,13 +928,11 @@ bool WalletImpl::init(const std::string &daemon_address, uint64_t upper_transact
 }
 
 #ifdef ENABLE_LIGHT_WALLET
-EXPORT
 bool WalletImpl::lightWalletLogin(bool &isNewWallet) const
 {
   return wallet()->light_wallet_login(isNewWallet);
 }
 
-EXPORT
 bool WalletImpl::lightWalletImportWalletRequest(std::string &payment_id, uint64_t &fee, bool &new_request, bool &request_fulfilled, std::string &payment_address, std::string &status)
 {
   try
@@ -1026,55 +959,46 @@ bool WalletImpl::lightWalletImportWalletRequest(std::string &payment_id, uint64_
 }
 #endif
 
-EXPORT
 void WalletImpl::setRefreshFromBlockHeight(uint64_t refresh_from_block_height)
 {
     wallet()->set_refresh_from_block_height(refresh_from_block_height);
 }
 
-EXPORT
 void WalletImpl::setRecoveringFromSeed(bool recoveringFromSeed)
 {
     m_recoveringFromSeed = recoveringFromSeed;
 }
 
-EXPORT
 void WalletImpl::setRecoveringFromDevice(bool recoveringFromDevice)
 {
     m_recoveringFromDevice = recoveringFromDevice;
 }
 
-EXPORT
 void WalletImpl::setSubaddressLookahead(uint32_t major, uint32_t minor)
 {
     wallet()->set_subaddress_lookahead(major, minor);
 }
 
-EXPORT
 uint64_t WalletImpl::balance(uint32_t accountIndex) const
 {
     return wallet()->balance(accountIndex, false);
 }
 
-EXPORT
 uint64_t WalletImpl::unlockedBalance(uint32_t accountIndex) const
 {
     return wallet()->unlocked_balance(accountIndex, false);
 }
 
-EXPORT
 uint64_t WalletImpl::accruedBalance(std::optional<std::string> address) const
 {
     return wallet()->get_batched_amount(std::move(address));
 }
 
-EXPORT
 uint64_t WalletImpl::nextAccruedPaymentHeight(std::optional<std::string> address) const
 {
     return wallet()->get_next_batch_payout(std::move(address));
 }
 
-EXPORT
 std::vector<Wallet::stake_info>* WalletImpl::listCurrentStakes() const
 {
     auto* stakes = new std::vector<Wallet::stake_info>;
@@ -1097,7 +1021,6 @@ std::vector<Wallet::stake_info>* WalletImpl::listCurrentStakes() const
     return stakes;
 }
 
-EXPORT
 uint64_t WalletImpl::blockChainHeight() const
 {
     // This call is thread-safe
@@ -1109,19 +1032,16 @@ uint64_t WalletImpl::blockChainHeight() const
 #endif
     return w->get_blockchain_current_height();
 }
-EXPORT
 uint64_t WalletImpl::approximateBlockChainHeight() const
 {
     return wallet()->get_approximate_blockchain_height();
 }
 
-EXPORT
 uint64_t WalletImpl::estimateBlockChainHeight() const
 {
     return wallet()->estimate_blockchain_height();
 }
 
-EXPORT
 uint64_t WalletImpl::daemonBlockChainHeight() const
 {
     // I *think* the calls here are thread-safe, so we can do this without locking
@@ -1147,7 +1067,6 @@ uint64_t WalletImpl::daemonBlockChainHeight() const
     return result;
 }
 
-EXPORT
 uint64_t WalletImpl::daemonBlockChainTargetHeight() const
 {
     // As above
@@ -1176,7 +1095,6 @@ uint64_t WalletImpl::daemonBlockChainTargetHeight() const
     return result;
 }
 
-EXPORT
 bool WalletImpl::daemonSynced() const
 {   
     if(connected() == Wallet::ConnectionStatus_Disconnected)
@@ -1185,13 +1103,11 @@ bool WalletImpl::daemonSynced() const
     return (blockChainHeight >= daemonBlockChainTargetHeight() && blockChainHeight > 1);
 }
 
-EXPORT
 bool WalletImpl::synchronized() const
 {
     return m_synchronized;
 }
 
-EXPORT
 bool WalletImpl::refresh()
 {
     clearStatus();
@@ -1201,7 +1117,6 @@ bool WalletImpl::refresh()
     return good();
 }
 
-EXPORT
 void WalletImpl::refreshAsync()
 {
     log::trace(logcat, "{}: Refreshing asynchronously..", __FUNCTION__);
@@ -1209,13 +1124,11 @@ void WalletImpl::refreshAsync()
     m_refreshCV.notify_one();
 }
 
-EXPORT
 bool WalletImpl::isRefreshing(std::chrono::milliseconds max_wait) {
     std::unique_lock lock{m_refreshMutex2, std::defer_lock};
     return !lock.try_lock_for(max_wait);
 }
 
-EXPORT
 bool WalletImpl::rescanBlockchain()
 {
     clearStatus();
@@ -1224,14 +1137,12 @@ bool WalletImpl::rescanBlockchain()
     return good();
 }
 
-EXPORT
 void WalletImpl::rescanBlockchainAsync()
 {
     m_refreshShouldRescan = true;
     refreshAsync();
 }
 
-EXPORT
 void WalletImpl::setAutoRefreshInterval(int millis)
 {
     if (millis > MAX_REFRESH_INTERVAL_MILLIS) {
@@ -1242,7 +1153,6 @@ void WalletImpl::setAutoRefreshInterval(int millis)
     }
 }
 
-EXPORT
 int WalletImpl::autoRefreshInterval() const
 {
     return m_refreshIntervalMillis;
@@ -1270,7 +1180,6 @@ UnsignedTransaction* WalletImpl::loadUnsignedTx(std::string_view unsigned_filena
   return transaction;
 }
 
-EXPORT
 bool WalletImpl::submitTransaction(std::string_view filename_) {
   auto fileName = fs::u8path(filename_);
   clearStatus();
@@ -1290,7 +1199,6 @@ bool WalletImpl::submitTransaction(std::string_view filename_) {
   return true;
 }
 
-EXPORT
 bool WalletImpl::exportKeyImages(std::string_view filename_) 
 {
   auto filename = fs::u8path(filename_);
@@ -1318,7 +1226,6 @@ bool WalletImpl::exportKeyImages(std::string_view filename_)
   return true;
 }
 
-EXPORT
 bool WalletImpl::importKeyImages(std::string_view filename_)
 {
   auto filename = fs::u8path(filename_);
@@ -1342,27 +1249,22 @@ bool WalletImpl::importKeyImages(std::string_view filename_)
   return true;
 }
 
-EXPORT
 void WalletImpl::addSubaddressAccount(const std::string& label)
 {
     wallet()->add_subaddress_account(label);
 }
-EXPORT
 size_t WalletImpl::numSubaddressAccounts() const
 {
     return wallet()->get_num_subaddress_accounts();
 }
-EXPORT
 size_t WalletImpl::numSubaddresses(uint32_t accountIndex) const
 {
     return wallet()->get_num_subaddresses(accountIndex);
 }
-EXPORT
 void WalletImpl::addSubaddress(uint32_t accountIndex, const std::string& label)
 {
     wallet()->add_subaddress(accountIndex, label);
 }
-EXPORT
 std::string WalletImpl::getSubaddressLabel(uint32_t accountIndex, uint32_t addressIndex) const
 {
     try
@@ -1376,7 +1278,6 @@ std::string WalletImpl::getSubaddressLabel(uint32_t accountIndex, uint32_t addre
         return "";
     }
 }
-EXPORT
 void WalletImpl::setSubaddressLabel(uint32_t accountIndex, uint32_t addressIndex, const std::string &label)
 {
     try
@@ -1396,13 +1297,11 @@ MultisigState WalletImpl::multisig(LockedWallet& w) {
     return state;
 }
 
-EXPORT
 MultisigState WalletImpl::multisig() const {
     auto w = wallet();
     return multisig(w);
 }
 
-EXPORT
 std::string WalletImpl::getMultisigInfo() const {
     try {
         clearStatus();
@@ -1415,7 +1314,6 @@ std::string WalletImpl::getMultisigInfo() const {
     return {};
 }
 
-EXPORT
 std::string WalletImpl::makeMultisig(const std::vector<std::string>& info, uint32_t threshold) {
     try {
         clearStatus();
@@ -1433,7 +1331,6 @@ std::string WalletImpl::makeMultisig(const std::vector<std::string>& info, uint3
     return {};
 }
 
-EXPORT
 std::string WalletImpl::exchangeMultisigKeys(const std::vector<std::string> &info) {
     try {
         clearStatus();
@@ -1449,7 +1346,6 @@ std::string WalletImpl::exchangeMultisigKeys(const std::vector<std::string> &inf
     return {};
 }
 
-EXPORT
 bool WalletImpl::finalizeMultisig(const std::vector<std::string>& extraMultisigInfo) {
     try {
         clearStatus();
@@ -1469,7 +1365,6 @@ bool WalletImpl::finalizeMultisig(const std::vector<std::string>& extraMultisigI
     return false;
 }
 
-EXPORT
 bool WalletImpl::exportMultisigImages(std::string& images) {
     try {
         clearStatus();
@@ -1487,7 +1382,6 @@ bool WalletImpl::exportMultisigImages(std::string& images) {
     return false;
 }
 
-EXPORT
 size_t WalletImpl::importMultisigImages(const std::vector<std::string>& images) {
     try {
         clearStatus();
@@ -1516,7 +1410,6 @@ size_t WalletImpl::importMultisigImages(const std::vector<std::string>& images) 
     return 0;
 }
 
-EXPORT
 bool WalletImpl::hasMultisigPartialKeyImages() const {
     try {
         clearStatus();
@@ -1532,7 +1425,6 @@ bool WalletImpl::hasMultisigPartialKeyImages() const {
     return false;
 }
 
-EXPORT
 PendingTransaction* WalletImpl::restoreMultisigTransaction(const std::string& signData) {
     try {
         clearStatus();
@@ -1568,7 +1460,6 @@ PendingTransaction* WalletImpl::restoreMultisigTransaction(const std::string& si
 //    - unconfirmed_transfer_details;
 //    - confirmed_transfer_details)
 
-EXPORT
 PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<std::string> &dst_addr, std::optional<std::vector<uint64_t>> amount, uint32_t priority, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices)
 
 {
@@ -1729,7 +1620,6 @@ PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<std:
     return transaction;
 }
 
-EXPORT
 PendingTransaction *WalletImpl::createTransaction(const std::string &dst_addr, std::optional<uint64_t> amount,
                                                   uint32_t priority, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices)
 
@@ -1737,7 +1627,6 @@ PendingTransaction *WalletImpl::createTransaction(const std::string &dst_addr, s
     return createTransactionMultDest(std::vector<std::string> {dst_addr},  amount ? (std::vector<uint64_t> {*amount}) : (std::optional<std::vector<uint64_t>>()), priority, subaddr_account, subaddr_indices);
 }
 
-EXPORT
 PendingTransaction *WalletImpl::createSweepUnmixableTransaction()
 
 {
@@ -1818,13 +1707,11 @@ PendingTransaction *WalletImpl::createSweepUnmixableTransaction()
     return transaction;
 }
 
-EXPORT
 void WalletImpl::disposeTransaction(PendingTransaction *t)
 {
     delete t;
 }
 
-EXPORT
 uint64_t WalletImpl::estimateTransactionFee(uint32_t priority, uint32_t recipients) const
 {
     constexpr uint32_t typical_size = 2000;
@@ -1834,51 +1721,43 @@ uint64_t WalletImpl::estimateTransactionFee(uint32_t priority, uint32_t recipien
     return (base_fee.first * typical_size + base_fee.second * (recipients + 1)) * pct / 100;
 }
 
-EXPORT
 TransactionHistory *WalletImpl::history()
 {
     return m_history.get();
 }
 
-EXPORT
 AddressBook *WalletImpl::addressBook()
 {
     return m_addressBook.get();
 }
 
-EXPORT
 Subaddress *WalletImpl::subaddress()
 {
     return m_subaddress.get();
 }
 
-EXPORT
 SubaddressAccount *WalletImpl::subaddressAccount()
 {
     return m_subaddressAccount.get();
 }
 
-EXPORT
 void WalletImpl::setListener(WalletListener *l)
 {
     // TODO thread synchronization;
     m_wallet2Callback->setListener(l);
 }
 
-EXPORT
 bool WalletImpl::setCacheAttribute(const std::string &key, const std::string &val)
 {
     wallet()->set_attribute(key, val);
     return true;
 }
 
-EXPORT
 std::string WalletImpl::getCacheAttribute(const std::string &key) const
 {
     return wallet()->get_attribute(key).value_or(""s);
 }
 
-EXPORT
 bool WalletImpl::setUserNote(const std::string &txid, const std::string &note)
 {
     crypto::hash htxid;
@@ -1889,7 +1768,6 @@ bool WalletImpl::setUserNote(const std::string &txid, const std::string &note)
     return true;
 }
 
-EXPORT
 std::string WalletImpl::getUserNote(const std::string &txid) const
 {
     crypto::hash htxid;
@@ -1899,7 +1777,6 @@ std::string WalletImpl::getUserNote(const std::string &txid) const
     return wallet()->get_tx_note(htxid);
 }
 
-EXPORT
 std::string WalletImpl::getTxKey(const std::string &txid_str) const
 {
     crypto::hash txid;
@@ -1936,7 +1813,6 @@ std::string WalletImpl::getTxKey(const std::string &txid_str) const
     }
 }
 
-EXPORT
 bool WalletImpl::checkTxKey(const std::string &txid_str, std::string_view tx_key_str, const std::string &address_str, uint64_t &received, bool &in_pool, uint64_t &confirmations)
 {
     crypto::hash txid;
@@ -1982,7 +1858,6 @@ bool WalletImpl::checkTxKey(const std::string &txid_str, std::string_view tx_key
     }
 }
 
-EXPORT
 std::string WalletImpl::getTxProof(const std::string &txid_str, const std::string &address_str, const std::string &message) const
 {
     crypto::hash txid;
@@ -2011,7 +1886,6 @@ std::string WalletImpl::getTxProof(const std::string &txid_str, const std::strin
     }
 }
 
-EXPORT
 bool WalletImpl::checkTxProof(const std::string &txid_str, const std::string &address_str, const std::string &message, const std::string &signature, bool &good, uint64_t &received, bool &in_pool, uint64_t &confirmations)
 {
     crypto::hash txid;
@@ -2041,7 +1915,6 @@ bool WalletImpl::checkTxProof(const std::string &txid_str, const std::string &ad
     }
 }
 
-EXPORT
 std::string WalletImpl::getSpendProof(const std::string &txid_str, const std::string &message) const {
     crypto::hash txid;
     if(!tools::hex_to_type(txid_str, txid))
@@ -2062,7 +1935,6 @@ std::string WalletImpl::getSpendProof(const std::string &txid_str, const std::st
     }
 }
 
-EXPORT
 bool WalletImpl::checkSpendProof(const std::string &txid_str, const std::string &message, const std::string &signature, bool &good) const {
     good = false;
     crypto::hash txid;
@@ -2085,7 +1957,6 @@ bool WalletImpl::checkSpendProof(const std::string &txid_str, const std::string 
     }
 }
 
-EXPORT
 std::string WalletImpl::getReserveProof(bool all, uint32_t account_index, uint64_t amount, const std::string &message) const {
     try
     {
@@ -2104,7 +1975,6 @@ std::string WalletImpl::getReserveProof(bool all, uint32_t account_index, uint64
     }
 }
 
-EXPORT
 bool WalletImpl::checkReserveProof(const std::string &address, const std::string &message, const std::string &signature, bool &good, uint64_t &total, uint64_t &spent) const {
     cryptonote::address_parse_info info;
     if (!cryptonote::get_account_address_from_str(info, m_wallet_ptr->nettype(), address))
@@ -2132,13 +2002,11 @@ bool WalletImpl::checkReserveProof(const std::string &address, const std::string
     }
 }
 
-EXPORT
 std::string WalletImpl::signMessage(const std::string &message)
 {
   return wallet()->sign(message);
 }
 
-EXPORT
 bool WalletImpl::verifySignedMessage(const std::string &message, const std::string &address, const std::string &signature) const
 {
   cryptonote::address_parse_info info;
@@ -2149,7 +2017,6 @@ bool WalletImpl::verifySignedMessage(const std::string &message, const std::stri
   return wallet()->verify(message, info.address, signature);
 }
 
-EXPORT
 std::string WalletImpl::signMultisigParticipant(const std::string &message) const
 {
     clearStatus();
@@ -2170,7 +2037,6 @@ std::string WalletImpl::signMultisigParticipant(const std::string &message) cons
     return {};
 }
 
-EXPORT
 bool WalletImpl::verifyMessageWithPublicKey(const std::string &message, const std::string &publicKey, const std::string &signature) const
 {
     clearStatus();
@@ -2188,7 +2054,6 @@ bool WalletImpl::verifyMessageWithPublicKey(const std::string &message, const st
     return false;
 }
 
-EXPORT
 bool WalletImpl::connectToDaemon()
 {
     auto w = wallet();
@@ -2202,7 +2067,6 @@ bool WalletImpl::connectToDaemon()
     return result;
 }
 
-EXPORT
 Wallet::ConnectionStatus WalletImpl::connected() const
 {
     rpc::version_t version;
@@ -2220,44 +2084,37 @@ Wallet::ConnectionStatus WalletImpl::connected() const
     return Wallet::ConnectionStatus_Connected;
 }
 
-EXPORT
 void WalletImpl::setTrustedDaemon(bool arg)
 {
     wallet()->set_trusted_daemon(arg);
 }
 
-EXPORT
 bool WalletImpl::trustedDaemon() const
 {
     return wallet()->is_trusted_daemon();
 }
 
-EXPORT
 bool WalletImpl::watchOnly() const
 {
     return wallet()->watch_only();
 }
 
-EXPORT
 void WalletImpl::clearStatus() const
 {
     std::lock_guard l{m_statusMutex};
     m_status = {Status_Ok, ""};
 }
 
-EXPORT
 bool WalletImpl::setStatusError(std::string message) const
 {
     return setStatus(Status_Error, std::move(message));
 }
 
-EXPORT
 bool WalletImpl::setStatusCritical(std::string message) const
 {
     return setStatus(Status_Critical, std::move(message));
 }
 
-EXPORT
 bool WalletImpl::setStatus(int status, std::string message) const
 {
     std::lock_guard l{m_statusMutex};
@@ -2266,7 +2123,6 @@ bool WalletImpl::setStatus(int status, std::string message) const
     return status == Status_Ok;
 }
 
-EXPORT
 void WalletImpl::refreshThreadFunc()
 {
     log::trace(logcat, "{}: starting refresh thread", __FUNCTION__);
@@ -2299,7 +2155,6 @@ void WalletImpl::refreshThreadFunc()
     log::trace(logcat, "{}: refresh thread stopped", __FUNCTION__);
 }
 
-EXPORT
 void WalletImpl::doRefresh()
 {
     bool rescan = m_refreshShouldRescan.exchange(false);
@@ -2345,7 +2200,6 @@ void WalletImpl::doRefresh()
 }
 
 
-EXPORT
 void WalletImpl::startRefresh()
 {
     if (!m_refreshEnabled) {
@@ -2357,7 +2211,6 @@ void WalletImpl::startRefresh()
 
 
 
-EXPORT
 void WalletImpl::stopRefresh()
 {
     if (!m_refreshThreadDone) {
@@ -2368,7 +2221,6 @@ void WalletImpl::stopRefresh()
     }
 }
 
-EXPORT
 void WalletImpl::pauseRefresh()
 {
     log::debug(logcat, "{}: refresh paused...", __FUNCTION__);
@@ -2379,7 +2231,6 @@ void WalletImpl::pauseRefresh()
 }
 
 
-EXPORT
 bool WalletImpl::isNewWallet() const
 {
     // in case wallet created without daemon connection, closed and opened again,
@@ -2390,7 +2241,6 @@ bool WalletImpl::isNewWallet() const
     return !(blockChainHeight() > 1 || m_recoveringFromSeed || m_recoveringFromDevice || m_rebuildWalletCache) && !watchOnly();
 }
 
-EXPORT
 void WalletImpl::pendingTxPostProcess(PendingTransactionImpl * pending)
 {
   // If the device being used is HW device with cold signing protocol, cold sign then.
@@ -2406,7 +2256,6 @@ void WalletImpl::pendingTxPostProcess(PendingTransactionImpl * pending)
   pending->m_pending_tx = exported_txs.ptx;
 }
 
-EXPORT
 bool WalletImpl::doInit(const std::string &daemon_address, uint64_t upper_transaction_size_limit, bool ssl)
 {
     auto w = wallet();
@@ -2434,19 +2283,16 @@ bool WalletImpl::doInit(const std::string &daemon_address, uint64_t upper_transa
     return true;
 }
 
-EXPORT
 bool WalletImpl::parse_uri(const std::string &uri, std::string &address, std::string &payment_id, uint64_t &amount, std::string &tx_description, std::string &recipient_name, std::vector<std::string> &unknown_parameters, std::string &error)
 {
     return m_wallet_ptr->parse_uri(uri, address, payment_id, amount, tx_description, recipient_name, unknown_parameters, error);
 }
 
-EXPORT
 std::string WalletImpl::getDefaultDataDir() const
 {
  return tools::get_default_data_dir();
 }
 
-EXPORT
 bool WalletImpl::rescanSpent()
 {
   clearStatus();
@@ -2465,13 +2311,11 @@ bool WalletImpl::rescanSpent()
 }
 
 
-EXPORT
 void WalletImpl::hardForkInfo(uint8_t &version, uint64_t &earliest_height) const
 {
     wallet()->get_hard_fork_info(version, earliest_height);
 }
 
-EXPORT
 std::optional<uint8_t> WalletImpl::hardForkVersion() const
 {
     auto v = m_wallet_ptr->get_hard_fork_version();
@@ -2480,13 +2324,11 @@ std::optional<uint8_t> WalletImpl::hardForkVersion() const
     return static_cast<uint8_t>(*v);
 }
 
-EXPORT
 bool WalletImpl::useForkRules(uint8_t version, int64_t early_blocks) const 
 {
     return wallet()->use_fork_rules(static_cast<hf>(version),early_blocks);
 }
 
-EXPORT
 bool WalletImpl::blackballOutputs(const std::vector<std::string> &outputs, bool add)
 {
     std::vector<std::pair<uint64_t, uint64_t>> raw_outputs;
@@ -2525,7 +2367,6 @@ bool WalletImpl::blackballOutputs(const std::vector<std::string> &outputs, bool 
     return true;
 }
 
-EXPORT
 bool WalletImpl::blackballOutput(const std::string &amount, const std::string &offset)
 {
     uint64_t raw_amount, raw_offset;
@@ -2548,7 +2389,6 @@ bool WalletImpl::blackballOutput(const std::string &amount, const std::string &o
     return true;
 }
 
-EXPORT
 bool WalletImpl::unblackballOutput(const std::string &amount, const std::string &offset)
 {
     uint64_t raw_amount, raw_offset;
@@ -2571,7 +2411,6 @@ bool WalletImpl::unblackballOutput(const std::string &amount, const std::string 
     return true;
 }
 
-EXPORT
 bool WalletImpl::getRing(const std::string &key_image, std::vector<uint64_t> &ring) const
 {
     crypto::key_image raw_key_image;
@@ -2589,7 +2428,6 @@ bool WalletImpl::getRing(const std::string &key_image, std::vector<uint64_t> &ri
     return true;
 }
 
-EXPORT
 bool WalletImpl::getRings(const std::string &txid, std::vector<std::pair<std::string, std::vector<uint64_t>>> &rings) const
 {
     crypto::hash raw_txid;
@@ -2612,7 +2450,6 @@ bool WalletImpl::getRings(const std::string &txid, std::vector<std::pair<std::st
     return true;
 }
 
-EXPORT
 bool WalletImpl::setRing(const std::string &key_image, const std::vector<uint64_t> &ring, bool relative)
 {
     crypto::key_image raw_key_image;
@@ -2630,43 +2467,36 @@ bool WalletImpl::setRing(const std::string &key_image, const std::vector<uint64_
     return true;
 }
 
-EXPORT
 void WalletImpl::segregatePreForkOutputs(bool segregate)
 {
     wallet()->segregate_pre_fork_outputs(segregate);
 }
 
-EXPORT
 void WalletImpl::segregationHeight(uint64_t height)
 {
     wallet()->segregation_height(height);
 }
 
-EXPORT
 void WalletImpl::keyReuseMitigation2(bool mitigation)
 {
     wallet()->key_reuse_mitigation2(mitigation);
 }
 
-EXPORT
 bool WalletImpl::lockKeysFile()
 {
     return wallet()->lock_keys_file();
 }
 
-EXPORT
 bool WalletImpl::unlockKeysFile()
 {
     return wallet()->unlock_keys_file();
 }
 
-EXPORT
 bool WalletImpl::isKeysFileLocked()
 {
     return wallet()->is_keys_file_locked();
 }
 
-EXPORT
 PendingTransaction* WalletImpl::stakePending(const std::string& sn_key_str, const uint64_t& amount)
 {
   /// Note(maxim): need to be careful to call `WalletImpl::disposeTransaction` when it is no longer needed
@@ -2695,7 +2525,6 @@ PendingTransaction* WalletImpl::stakePending(const std::string& sn_key_str, cons
   return transaction;
 }
 
-EXPORT
 StakeUnlockResult* WalletImpl::canRequestStakeUnlock(const std::string &sn_key)
 {
     crypto::public_key snode_key;
@@ -2710,7 +2539,6 @@ StakeUnlockResult* WalletImpl::canRequestStakeUnlock(const std::string &sn_key)
     return new StakeUnlockResultImpl(*this, wallet()->can_request_stake_unlock(snode_key));
 }
 
-EXPORT
 StakeUnlockResult* WalletImpl::requestStakeUnlock(const std::string &sn_key)
 {
     tools::wallet2::request_stake_unlock_result res = {};
@@ -2747,13 +2575,11 @@ StakeUnlockResult* WalletImpl::requestStakeUnlock(const std::string &sn_key)
     return new StakeUnlockResultImpl(*this, unlock_result);
 }
 
-EXPORT
 uint64_t WalletImpl::coldKeyImageSync(uint64_t &spent, uint64_t &unspent)
 {
     return wallet()->cold_key_image_sync(spent, unspent);
 }
 
-EXPORT
 void WalletImpl::deviceShowAddress(uint32_t accountIndex, uint32_t addressIndex, const std::string &paymentId)
 {
     std::optional<crypto::hash8> payment_id_param = std::nullopt;

--- a/src/wallet/api/wallet_manager.cpp
+++ b/src/wallet/api/wallet_manager.cpp
@@ -41,7 +41,6 @@
 
 namespace Wallet {
 
-EXPORT
 Wallet* WalletManagerImpl::createWallet(std::string_view path, const std::string &password,
                                     const std::string &language, NetworkType nettype, uint64_t kdf_rounds)
 {
@@ -50,7 +49,6 @@ Wallet* WalletManagerImpl::createWallet(std::string_view path, const std::string
     return wallet;
 }
 
-EXPORT
 Wallet* WalletManagerImpl::openWallet(std::string_view path, const std::string &password, NetworkType nettype, uint64_t kdf_rounds, WalletListener * listener)
 {
     WalletImpl* wallet = new WalletImpl(nettype, kdf_rounds);
@@ -65,7 +63,6 @@ Wallet* WalletManagerImpl::openWallet(std::string_view path, const std::string &
     return wallet;
 }
 
-EXPORT
 Wallet* WalletManagerImpl::recoveryWallet(std::string_view path,
                                                 const std::string &password,
                                                 const std::string &mnemonic,
@@ -82,7 +79,6 @@ Wallet* WalletManagerImpl::recoveryWallet(std::string_view path,
     return wallet;
 }
 
-EXPORT
 Wallet* WalletManagerImpl::createWalletFromKeys(std::string_view path,
                                                 const std::string &password,
                                                 const std::string &language,
@@ -101,7 +97,6 @@ Wallet* WalletManagerImpl::createWalletFromKeys(std::string_view path,
     return wallet;
 }
 
-EXPORT
 Wallet* WalletManagerImpl::createWalletFromDevice(std::string_view path,
                                                   const std::string &password,
                                                   NetworkType nettype,
@@ -131,7 +126,6 @@ Wallet* WalletManagerImpl::createWalletFromDevice(std::string_view path,
     return wallet;
 }
 
-EXPORT
 bool WalletManagerImpl::closeWallet(Wallet* wallet, bool store)
 {
     WalletImpl* wallet_ = dynamic_cast<WalletImpl*>(wallet);
@@ -146,7 +140,6 @@ bool WalletManagerImpl::closeWallet(Wallet* wallet, bool store)
     return result;
 }
 
-EXPORT
 bool WalletManagerImpl::walletExists(std::string_view path)
 {
     bool keys_file_exists;
@@ -158,13 +151,11 @@ bool WalletManagerImpl::walletExists(std::string_view path)
     return false;
 }
 
-EXPORT
 bool WalletManagerImpl::verifyWalletPassword(std::string_view keys_file_name, const std::string &password, bool no_spend_key, uint64_t kdf_rounds) const
 {
 	    return tools::wallet2::verify_password(fs::u8path(keys_file_name), password, no_spend_key, hw::get_device("default"), kdf_rounds);
 }
 
-EXPORT
 bool WalletManagerImpl::queryWalletDevice(Wallet::Device& device_type, std::string_view keys_file_name, const std::string &password, uint64_t kdf_rounds) const
 {
     hw::device::type type;
@@ -173,7 +164,6 @@ bool WalletManagerImpl::queryWalletDevice(Wallet::Device& device_type, std::stri
     return r;
 }
 
-EXPORT
 std::vector<std::string> WalletManagerImpl::findWallets(std::string_view path_)
 {
     auto path = fs::u8path(path_);
@@ -202,13 +192,11 @@ std::vector<std::string> WalletManagerImpl::findWallets(std::string_view path_)
     return result;
 }
 
-EXPORT
 std::string WalletManagerImpl::errorString() const
 {
     return m_errorString;
 }
 
-EXPORT
 void WalletManagerImpl::setDaemonAddress(std::string address)
 {
     if (!tools::starts_with(address, "https://") && !tools::starts_with(address, "http://"))
@@ -216,7 +204,6 @@ void WalletManagerImpl::setDaemonAddress(std::string address)
     m_http_client.set_base_url(std::move(address));
 }
 
-EXPORT
 bool WalletManagerImpl::connected(uint32_t *version)
 {
     using namespace cryptonote::rpc;
@@ -235,14 +222,12 @@ static nlohmann::json get_info(cryptonote::rpc::http_client& http)
 }
 
 
-EXPORT
 uint64_t WalletManagerImpl::blockchainHeight()
 {
     auto res = get_info(m_http_client);
     return res ? res["height"].get<uint64_t>() : 0;
 }
 
-EXPORT
 uint64_t WalletManagerImpl::blockchainTargetHeight()
 {
     auto res = get_info(m_http_client);
@@ -251,7 +236,6 @@ uint64_t WalletManagerImpl::blockchainTargetHeight()
     return std::max(res["target_height"].get<uint64_t>(), res["height"].get<uint64_t>());
 }
 
-EXPORT
 uint64_t WalletManagerImpl::blockTarget()
 {
     auto res = get_info(m_http_client);
@@ -259,7 +243,6 @@ uint64_t WalletManagerImpl::blockTarget()
 }
 
 ///////////////////// WalletManagerFactory implementation //////////////////////
-EXPORT
 WalletManagerBase *WalletManagerFactory::getWalletManager()
 {
 
@@ -272,7 +255,6 @@ WalletManagerBase *WalletManagerFactory::getWalletManager()
     return g_walletManager;
 }
 
-EXPORT
 void WalletManagerFactory::setLogLevel(int level)
 {
     auto log_level = oxen::logging::parse_level(level);
@@ -280,7 +262,6 @@ void WalletManagerFactory::setLogLevel(int level)
       log::reset_level(*log_level);
 }
 
-EXPORT
 void WalletManagerFactory::setLogCategories(const std::string &categories)
 {
     oxen::logging::process_categories_string(categories);


### PR DESCRIPTION
GCC hides symbols so the wallet api was for every function setting the visibility to default, change so that this setting is the default for compiler and remove the macro which would conflict with c++20 when the export keyword is brought back.